### PR TITLE
Fix the package.json license to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "yargs": "6.6.0"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "atob": "^2.0.3",
     "basename": "^0.1.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Fixes the `license` property in the `package.json` file to be the same license as in the `LICENSE` file (MIT). Damn `npm init` default of ISC, ney?