### PR TITLE
Handle custom provider id for authentication with redirect

### DIFF
--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -3,7 +3,10 @@ import connector, { logInWithPopUp } from "./connector";
 
 import { jso_wipe } from "../jso";
 
-export default ({ api_token, access_token, popupMode }, reset) => {
+export default (
+  { api_token, access_token, provider = "cg", popupMode },
+  reset
+) => {
   let promise;
 
   if (access_token) {
@@ -12,7 +15,7 @@ export default ({ api_token, access_token, popupMode }, reset) => {
     if (popupMode) {
       promise = logInWithPopUp(reset);
     } else {
-      promise = connector(api_token, reset);
+      promise = connector(api_token, reset, { provider });
     }
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,20 +1,27 @@
-const DEFAULT_ACCOUNT_URL = 'https://accounts.platform.sh';
-const DEFAULT_API_URL = 'https://api.platform.sh/api';
+const DEFAULT_ACCOUNT_URL = "https://accounts.platform.sh";
+const DEFAULT_API_URL = "https://api.platform.sh/api";
 
-const getConfigDefault = (baseUrl = DEFAULT_ACCOUNT_URL, api_url = DEFAULT_API_URL) => ({
-  'client_id': 'platform@d4tobd5qpizwa.eu.platform.sh',
-  'account_url': `${baseUrl}/api`,
+const getConfigDefault = (
+  baseUrl = DEFAULT_ACCOUNT_URL,
+  api_url = DEFAULT_API_URL
+) => ({
+  provider: "cg",
+  client_id: "platform@d4tobd5qpizwa.eu.platform.sh",
+  account_url: `${baseUrl}/api`,
   api_url,
-  'authentication_url': baseUrl,
+  authentication_url: baseUrl,
   scope: [],
   authorization: `${baseUrl}/oauth2/authorize`,
-  'logout_url': `${baseUrl}/user/logout`
+  logout_url: `${baseUrl}/user/logout`
 });
 
 let config = getConfigDefault();
 
 export const setConfig = newConfig => {
-  config = {...getConfigDefault(newConfig.base_url, newConfig.api_url), ...newConfig};
+  config = {
+    ...getConfigDefault(newConfig.base_url, newConfig.api_url),
+    ...newConfig
+  };
 };
 
 export const getConfig = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,6 @@ export default class Client {
   constructor(authenticationConfig = {}) {
     setConfig(authenticationConfig);
 
-    const { api_token, access_token, ...config } = authenticationConfig;
-
     this.authenticationPromise = connector(authenticationConfig);
   }
 

--- a/src/jso/ApiDefaultStorage.js
+++ b/src/jso/ApiDefaultStorage.js
@@ -8,18 +8,18 @@ export default class ApiDefaultStorage {
   * scopes
 
   */
-  saveState(state, obj) {
-    localStorage.setItem("state-" + state, JSON.stringify(obj));
+  saveState(state, providerId, obj) {
+    localStorage.setItem(`state-${providerId}-${state}`, JSON.stringify(obj));
   }
 
   /**
    * getStage()  returns the state object, but also removes it.
    * @type {Object}
    */
-  getState(state) {
-    var obj = JSON.parse(localStorage.getItem("state-" + state));
+  getState(state, providerId) {
+    var obj = JSON.parse(localStorage.getItem(`state-${providerId}-${state}`));
 
-    localStorage.removeItem("state-" + state);
+    localStorage.removeItem(`state-${providerId}-${state}`);
     return obj;
   }
 
@@ -75,11 +75,11 @@ export default class ApiDefaultStorage {
   * scopes: an array with the scopes (not string)
   */
   saveTokens(provider, tokens) {
-    localStorage.setItem("tokens-" + provider, JSON.stringify(tokens));
+    localStorage.setItem(`tokens-${provider}`, JSON.stringify(tokens));
   }
 
   getTokens(provider) {
-    var tokens = JSON.parse(localStorage.getItem("tokens-" + provider));
+    var tokens = JSON.parse(localStorage.getItem(`tokens-${provider}`));
 
     if (!tokens) tokens = [];
 
@@ -87,7 +87,7 @@ export default class ApiDefaultStorage {
   }
 
   wipeTokens(provider) {
-    localStorage.removeItem("tokens-" + provider);
+    localStorage.removeItem(`tokens-${provider}`);
   }
 
   /*

--- a/src/jso/index.js
+++ b/src/jso/index.js
@@ -119,14 +119,14 @@ api_storage = new ApiDefaultStorage();
  * childbrowser when the jso context is not receiving the response,
  * instead the response is received on a child browser.
  */
-export const jso_checkfortoken = (providerID, url, disableRedirect) => {
+export const jso_checkfortoken = (clientId, provider, url, disableRedirect) => {
   let atoken,
     h = window.location.hash,
     now = epoch(),
     state,
     co;
 
-  log(`jso_checkfortoken(${providerID})`);
+  log(`jso_checkfortoken(${clientId})`);
 
   // If a url is provided
   if (url) {
@@ -145,14 +145,14 @@ export const jso_checkfortoken = (providerID, url, disableRedirect) => {
   atoken = parseQueryString(h);
 
   if (atoken.state) {
-    state = api_storage.getState(atoken.state);
+    state = api_storage.getState(atoken.state, provider);
   } else {
-    if (!providerID) {
+    if (!clientId) {
       throw new Error(
         "Could not get [state] and no default providerid is provided."
       );
     }
-    state = { providerID: providerID };
+    state = { providerID: clientId };
   }
 
   if (!state) throw new Error("Could not retrieve state");
@@ -269,7 +269,7 @@ export const jso_getAuthUrl = (providerid, scopes, callback) => {
   log(`Saving state [${state}]`);
   log(JSON.parse(JSON.stringify(request)));
 
-  api_storage.saveState(state, request);
+  api_storage.saveState(state, providerid, request);
 
   return authurl;
 };
@@ -316,7 +316,7 @@ export const jso_getAuthRequest = (providerid, scopes, callback) => {
   log(`Saving state [${state}]`);
   log(JSON.parse(JSON.stringify(request)));
 
-  api_storage.saveState(state, request);
+  api_storage.saveState(state, providerid, request);
 
   return request;
 };
@@ -368,7 +368,7 @@ const jso_authrequest = (providerid, scopes, callback) => {
   log(`Saving state [${state}]`);
   log(JSON.parse(JSON.stringify(request)));
 
-  api_storage.saveState(state, request);
+  api_storage.saveState(state, providerid, request);
   api_redirect(authurl);
 };
 
@@ -425,7 +425,7 @@ export const jso_configure = (c, opts, popupMode) => {
 
     if (!popupMode) {
       log("jso_configure() about to check for token for this entry", def);
-      jso_checkfortoken(def);
+      jso_checkfortoken(c[def].client_id, def);
     }
   } catch (e) {
     log("Error when retrieving token from hash: " + e);


### PR DESCRIPTION
This PR add the `provider` key to the config, allowing to custom this string to use multiple clients in the same page, scoping the tokens and states.