### PR TITLE
Properly import/export Integration modal

### DIFF
--- a/src/model/Integration.js
+++ b/src/model/Integration.js
@@ -45,7 +45,7 @@ export default class Integration extends Ressource {
 
     return super.get(
       customUrl ? `${customUrl}/:id` : `${api_url}${_url}/:id`,
-      { id },
+      { projectId, id },
       paramDefaults,
       queryParams
     );

--- a/src/model/Integration.js
+++ b/src/model/Integration.js
@@ -1,19 +1,30 @@
-import Ressource from './Ressource';
-import {request} from '../api';
-import { getConfig } from '../config';
+import Ressource from "./Ressource";
+import { request } from "../api";
+import { getConfig } from "../config";
 
 const paramDefaults = {};
-const types = ['bitbucket', 'bitbucket_server', 'github', 'gitlab', 'hipchat', 'webhook', 'health.email', 'health.pagerduty', 'health.slack', 'script'];
-const _url = '/projects/:projectId/integrations';
+const types = [
+  "bitbucket",
+  "bitbucket_server",
+  "github",
+  "gitlab",
+  "hipchat",
+  "webhook",
+  "health.email",
+  "health.pagerduty",
+  "health.slack",
+  "script"
+];
+const _url = "/projects/:projectId/integrations";
 
 export default class Integration extends Ressource {
   constructor(integration, url) {
     const { id } = integration;
 
-    super(url, paramDefaults, { id }, integration, ['type']);
-    this._required = ['type'];
-    this.id = '';
-    this.type = '';
+    super(url, paramDefaults, { id }, integration, ["type"]);
+    this._required = ["type"];
+    this.id = "";
+    this.type = "";
   }
 
   /**
@@ -22,7 +33,7 @@ export default class Integration extends Ressource {
   checkProperty(property, value) {
     const errors = {};
 
-    if (property === 'type' && types.indexOf(value) === -1) {
+    if (property === "type" && types.indexOf(value) === -1) {
       errors[property] = `Invalid type: '${value}'`;
     }
     return errors;
@@ -32,14 +43,25 @@ export default class Integration extends Ressource {
     const { projectId, id, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.get(customUrl ? `${customUrl}/:id` : `${api_url}${_url}/:id`, { id }, paramDefaults, queryParams);
+    return super.get(
+      customUrl ? `${customUrl}/:id` : `${api_url}${_url}/:id`,
+      { id },
+      paramDefaults,
+      queryParams
+    );
   }
 
   static query(params, customUrl) {
     const { projectId, ...queryParams } = params;
     const { api_url } = getConfig();
+    debugger;
 
-    return super.query(customUrl || `${api_url}${_url}`, { projectId }, paramDefaults, queryParams);
+    return super.query(
+      customUrl || `${api_url}${_url}`,
+      { projectId },
+      paramDefaults,
+      queryParams
+    );
   }
 
   /**
@@ -49,8 +71,8 @@ export default class Integration extends Ressource {
    * it may be useful to trigger the hook manually in certain cases.
    */
   triggerHook() {
-    const hookUrl = this.getLink('#hook');
+    const hookUrl = this.getLink("#hook");
 
-    return request(hookUrl, 'post');
+    return request(hookUrl, "post");
   }
 }

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -23,6 +23,7 @@ import AccountsProfile from "./AccountsProfile";
 import SetupRegistry from "./SetupRegistry";
 import SetupConfig from "./SetupConfig";
 import AuthUser from "./AuthUser";
+import Integration from "./Integration";
 
 export default {
   Account,
@@ -49,5 +50,6 @@ export default {
   AccountsProfile,
   SetupRegistry,
   SetupConfig,
-  AuthUser
+  AuthUser,
+  Integration
 };


### PR DESCRIPTION
- Export Integration as a modal
- Change a bunch lines that prettier did automatically
- Fix `Integration.get()` so that `projectId` is passed to `super.get()` and the `:projectId` in the path is properly replaced. 