### PR TITLE
Fills the description property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "platformsh-client",
   "version": "0.1.112",
-  "description": "",
+  "description": "Isomorphic Javascript library for accessing the Platform.sh API",
   "browser": "lib/client/platform-api.js",
   "main": "lib/server/platform-api.js",
   "scripts": {


### PR DESCRIPTION
This description is used on registries, if empty they might take the
first couple of lines in the README.md, right now that's a link to the
build status

![image](https://user-images.githubusercontent.com/1609683/80687387-80f83b00-8aca-11ea-84e1-56b0aa7c4339.png)
![image](https://user-images.githubusercontent.com/1609683/80687434-940b0b00-8aca-11ea-80bd-5f9af0f71738.png)
