### PR TITLE
Fixes eslint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,4 @@
 {
-  "ecmaFeatures": {
-    "globalReturn": true,
-    "modules": true
-  },
-
   "env": {
     "browser": true,
     "es6": true,

--- a/src/model/Activity.js
+++ b/src/model/Activity.js
@@ -1,65 +1,75 @@
-import Ressource from './Ressource';
-import { getConfig } from '../config';
-import request from '../api';
+import Ressource from "./Ressource";
+import { getConfig } from "../config";
+import request from "../api";
 
 const paramDefaults = {};
-const _url = '/projects/:projectId/environments/:environmentId/activities';
+const _url = "/projects/:projectId/environments/:environmentId/activities";
 
 export default class Activity extends Ressource {
   constructor(activity, url) {
-    super(url, paramDefaults, {}, activity, ['name', 'ssl']);
-    this.id = '';
+    super(url, paramDefaults, {}, activity, ["name", "ssl"]);
+    this.id = "";
     this.completion_percent = 0;
-    this.log = '';
-    this.created_at = '';
-    this.updated_at = '';
+    this.log = "";
+    this.created_at = "";
+    this.updated_at = "";
     this.environments = [];
-    this.completed_at = '';
+    this.completed_at = "";
     this.parameters = [];
-    this.project = '';
-    this.state = '';
-    this.result = '';
-    this.started_at = '';
-    this.type = '';
+    this.project = "";
+    this.state = "";
+    this.result = "";
+    this.started_at = "";
+    this.type = "";
     this.payload = [];
-    this.RESULT_SUCCESS = 'success';
-    this.RESULT_FAILURE = 'failure';
-    this.STATE_COMPLETE = 'complete';
-    this.STATE_IN_PROGRESS = 'in_progress';
-    this.STATE_PENDING = 'pending';
+    this.RESULT_SUCCESS = "success";
+    this.RESULT_FAILURE = "failure";
+    this.STATE_COMPLETE = "complete";
+    this.STATE_IN_PROGRESS = "in_progress";
+    this.STATE_PENDING = "pending";
   }
 
   static get(params, customUrl) {
     const { projectId, environmentId, id, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.get(customUrl ? `${customUrl}/:id` : `${api_url}${_url}/:id`, { id }, paramDefaults, queryParams);
+    return super.get(
+      customUrl ? `${customUrl}/:id` : `${api_url}${_url}/:id`,
+      { id },
+      paramDefaults,
+      queryParams
+    );
   }
 
   static query(params, customUrl) {
     const { projectId, environmentId, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.query(customUrl || `${api_url}${_url}`, { projectId, environmentId }, paramDefaults, queryParams);
+    return super.query(
+      customUrl || `${api_url}${_url}`,
+      { projectId, environmentId },
+      paramDefaults,
+      queryParams
+    );
   }
 
   /**
-  * Wait for the activity to complete.
-  *
-  * @todo use the FutureInterface
-  *
-  * @param function  onPoll       A function that will be called every time
-  *                                the activity is polled for updates. It
-  *                                will be passed one argument: the
-  *                                Activity object.
-  * @param function  onLog        A function that will print new activity log
-  *                                messages as they are received. It will be
-  *                                passed one argument: the message as a
-  *                                string.
-  * @param int|float pollInterval The polling interval, in seconds.
-  */
+   * Wait for the activity to complete.
+   *
+   * @todo use the FutureInterface
+   *
+   * @param function  onPoll       A function that will be called every time
+   *                                the activity is polled for updates. It
+   *                                will be passed one argument: the
+   *                                Activity object.
+   * @param function  onLog        A function that will print new activity log
+   *                                messages as they are received. It will be
+   *                                passed one argument: the message as a
+   *                                string.
+   * @param int|float pollInterval The polling interval, in seconds.
+   */
   wait(onPoll, onLog, pollInterval = 1) {
-    const log = this.log || '';
+    const log = this.log || "";
 
     if (onLog && log.trim().length) {
       onLog(`${log.trim()}\n`);
@@ -69,76 +79,80 @@ export default class Activity extends Ressource {
 
     return new Promise((resolve, reject) => {
       const interval = setInterval(() => {
-        if(this.isComplete()) {
+        if (this.isComplete()) {
           resolve(this);
           clearInterval(interval);
         }
 
-        this.refresh({ 'timeout': pollInterval + 5 }).then(activity => {
-          if (onPoll) {
-            onPoll(activity);
-          }
+        this.refresh({ timeout: pollInterval + 5 })
+          .then(activity => {
+            if (onPoll) {
+              onPoll(activity);
+            }
 
-          if (onLog) {
-            const newLog = (this.log || '').substring(length);
+            if (onLog) {
+              const newLog = (this.log || "").substring(length);
 
-            onLog(`${newLog.trim()}\n`);
-            length = newLog.length;
-          }
-        })
-        .catch(err => {
-          if (err.message.indexOf('cURL error 28') !== -1 && retries <= 5) {
-            return retries++;
-          }
+              onLog(`${newLog.trim()}\n`);
+              length = newLog.length;
+            }
+          })
+          .catch(err => {
+            if (err.message.indexOf("cURL error 28") !== -1 && retries <= 5) {
+              return retries++;
+            }
 
-          reject(err);
-        });
+            reject(err);
+          });
       }, pollInterval * 1000);
     });
   }
 
   /**
-  * Determine whether the activity is complete.
-  *
-  * @return bool
-  */
+   * Determine whether the activity is complete.
+   *
+   * @return bool
+   */
   isComplete() {
     return this.getCompletionPercent() >= 100;
   }
 
   /**
-  * Get the completion progress of the activity, in percent.
-  *
-  * @return int
-  */
+   * Get the completion progress of the activity, in percent.
+   *
+   * @return int
+   */
   getCompletionPercent() {
     return parseInt(this.completion_percent);
   }
 
   /**
-  * Restore the backup associated with this activity.
-  *
-  * @return Activity
-  */
+   * Restore the backup associated with this activity.
+   *
+   * @return Activity
+   */
   restore() {
-    if (this.type !== 'environment.backup') {
-      throw new Error('Cannot restore activity (wrong type)');
+    if (this.type !== "environment.backup") {
+      throw new Error("Cannot restore activity (wrong type)");
     }
     if (!this.isComplete()) {
-      throw new Error('Cannot restore backup (not complete)');
+      throw new Error("Cannot restore backup (not complete)");
     }
 
-    return this.runLongOperation('restore', 'POST', {});
+    return this.runLongOperation("restore", "POST", {});
   }
 
   getLogAt(start_at, delay) {
-    if(delay) {
+    if (delay) {
       return new Promise(resolve => {
-        setTimeout(() => resolve(request(this.getLink('log'), 'GET', { start_at })), delay);
+        setTimeout(
+          () => resolve(request(this.getLink("log"), "GET", { start_at })),
+          delay
+        );
       });
     }
 
-    return request(this.getLink('log'), 'GET', { start_at });
+    return request(this.getLink("log"), "GET", { start_at });
   }
 
   getLogs(callback) {
@@ -151,7 +165,7 @@ export default class Activity extends Ressource {
     return {
       cancel,
       exec: async () => {
-        if(!this.hasLink('log')) {
+        if (!this.hasLink("log")) {
           return callback(this.log);
         }
 
@@ -160,11 +174,15 @@ export default class Activity extends Ressource {
         let attempts = 0;
         let delay = 0;
 
-        while((!lastResponse || !(lastResponse[lastResponse.data.length - 1].seal)) && attempts < 5 && !canceled) {
+        while (
+          (!lastResponse || !lastResponse[lastResponse.data.length - 1].seal) &&
+          attempts < 5 &&
+          !canceled
+        ) {
           try {
             const textJsonLog = await this.getLogAt(starts_at, delay);
 
-            if(!textJsonLog || !textJsonLog.length) {
+            if (!textJsonLog || !textJsonLog.length) {
               delay = 3000;
               attempts++;
               continue;
@@ -172,7 +190,8 @@ export default class Activity extends Ressource {
 
             delay = 0;
             attempts = 0;
-            const logs = textJsonLog.split('\n')
+            const logs = textJsonLog
+              .split("\n")
               .filter(line => line.length)
               .map(log => JSON.parse(log));
 
@@ -180,11 +199,11 @@ export default class Activity extends Ressource {
             starts_at++;
             callback(logs);
 
-            if(logs[logs.length - 1].seal) {
+            if (logs[logs.length - 1].seal) {
               break;
             }
-          } catch(response) {
-            if(response.status < 500 || response.status > 599) {
+          } catch (response) {
+            if (response.status < 500 || response.status > 599) {
               callback({}, response);
             }
 
@@ -197,75 +216,127 @@ export default class Activity extends Ressource {
   }
 
   /**
-  * Get a human-readable description of the activity.
-  *
-  * @return string
-  */
+   * Get a human-readable description of the activity.
+   *
+   * @return string
+   */
   getDescription() {
     const type = this.type;
     const payload = this.payload;
 
     switch (type) {
-      case 'project.domain.create':
-        return `${payload.user.display_name} added domain ${payload.domain.name}`;
-      case 'project.domain.delete':
-        return `${payload.user.display_name} deleted domain ${payload.domain.name}`;
-      case 'project.domain.update':
-        return `${payload.user.display_name} updated domain ${payload.domain.name}`;
-      case 'project.modify.title':
-        return `${payload.user.display_name} changed project name to ${payload.new_title}`;
-      case 'environment.activate':
-        return `${payload.user.display_name} activated environment ${payload.environment.title}`;
-      case 'environment.backup':
-        return `${payload.user.display_name} created a snapshot of ${payload.environment.title}`;
-      case 'environment.branch':
-        return `${payload.user.display_name} branched ${payload.outcome.title} from ${payload.parent.title}`;
-      case 'environment.delete':
-        return `${payload.user.display_name} deleted environment ${payload.environment.title}`;
-      case 'environment.deactivate':
-        return `${payload.user.display_name} deactivated environment ${payload.environment.title}`;
-      case 'environment.initialize':
-        return `${payload.user.display_name} initialized environment ${payload.outcome.title} with profile ${payload.profile}`; // eslint-disable-line max-len
-      case 'environment.merge':
-        return `${payload.user.display_name} merged ${payload.outcome.title} into ${payload.environment.title}`;
-      case 'environment.push':
-        return `${payload.user.display_name} pushed to ${payload.environment.title}`;
-      case 'environment.restore':
-        return `${payload.user.display_name} restored ${payload.environment} from snapshot ${payload.backup_name.substr(0, 7)}`; // eslint-disable-line max-len
-      case 'environment.synchronize':
-        const syncedCode = !payload['synchronize_code'];
-        let syncType = 'data';
+      case "project.domain.create":
+        return `${payload.user.display_name} added domain ${
+          payload.domain.name
+        }`;
+      case "project.domain.delete":
+        return `${payload.user.display_name} deleted domain ${
+          payload.domain.name
+        }`;
+      case "project.domain.update":
+        return `${payload.user.display_name} updated domain ${
+          payload.domain.name
+        }`;
+      case "project.modify.title":
+        return `${payload.user.display_name} changed project name to ${
+          payload.new_title
+        }`;
+      case "environment.activate":
+        return `${payload.user.display_name} activated environment ${
+          payload.environment.title
+        }`;
+      case "environment.backup":
+        return `${payload.user.display_name} created a snapshot of ${
+          payload.environment.title
+        }`;
+      case "environment.branch":
+        return `${payload.user.display_name} branched ${
+          payload.outcome.title
+        } from ${payload.parent.title}`;
+      case "environment.delete":
+        return `${payload.user.display_name} deleted environment ${
+          payload.environment.title
+        }`;
+      case "environment.deactivate":
+        return `${payload.user.display_name} deactivated environment ${
+          payload.environment.title
+        }`;
+      case "environment.initialize":
+        return `${payload.user.display_name} initialized environment ${
+          payload.outcome.title
+        } with profile ${payload.profile}`; // eslint-disable-line max-len
+      case "environment.merge":
+        return `${payload.user.display_name} merged ${
+          payload.outcome.title
+        } into ${payload.environment.title}`;
+      case "environment.push":
+        return `${payload.user.display_name} pushed to ${
+          payload.environment.title
+        }`;
+      case "environment.restore":
+        return `${payload.user.display_name} restored ${
+          payload.environment
+        } from snapshot ${payload.backup_name.substr(0, 7)}`; // eslint-disable-line max-len
+      case "environment.synchronize":
+        const syncedCode = !payload["synchronize_code"];
+        let syncType = "data";
 
-        if(syncedCode && !payload['synchronize_data']) {
-          syncType = 'code and data';
+        if (syncedCode && !payload["synchronize_data"]) {
+          syncType = "code and data";
         } else if (syncedCode) {
-          syncType = 'code';
+          syncType = "code";
         }
-        return `${payload.user.display_name} synced ${payload.outcome.title}'s ${syncType} with ${payload.environment.title}`; // eslint-disable-line max-len
-      case 'environment.access.add':
-        return `${payload.user.display_name} added ${payload.access.display_name} to ${payload.environment.title}`;
-      case 'environment.access.remove':
-        return `${payload.user.display_name} removed ${payload.access.display_name} from ${payload.environment.title}`;
-      case 'environment.variable.create':
-        return `${payload.user.display_name} added variable ${payload.variable.name}`;
-      case 'environment.variable.delete':
-        return `${payload.user.display_name} deleted variable ${payload.variable.name}`;
-      case 'environment.variable.update':
-        return `${payload.user.display_name} modified variable ${payload.variable.name}`;
-      case 'environment.update.http_access':
-        return `${payload.user.display_name} updated HTTP Access settings on environment ${payload.environment.title}`;
-      case 'environment.update.smtp':
-        return `${payload.user.display_name} updated SMTP settings on environment ${payload.environment.title}`;
-      case 'environment.route.create':
-        return `${payload.user.display_name} added route ${payload.route.route}`;
-      case 'environment.route.delete':
-        return `${payload.user.display_name} deleted route ${payload.route.route}`;
-      case 'environment.route.update':
-        return `${payload.user.display_name} modified route ${payload.route.route}`;
-      case 'environment.subscription.update':
+        return `${payload.user.display_name} synced ${
+          payload.outcome.title
+        }'s ${syncType} with ${payload.environment.title}`; // eslint-disable-line max-len
+      case "environment.access.add":
+        return `${payload.user.display_name} added ${
+          payload.access.display_name
+        } to ${payload.environment.title}`;
+      case "environment.access.remove":
+        return `${payload.user.display_name} removed ${
+          payload.access.display_name
+        } from ${payload.environment.title}`;
+      case "environment.variable.create":
+        return `${payload.user.display_name} added variable ${
+          payload.variable.name
+        }`;
+      case "environment.variable.delete":
+        return `${payload.user.display_name} deleted variable ${
+          payload.variable.name
+        }`;
+      case "environment.variable.update":
+        return `${payload.user.display_name} modified variable ${
+          payload.variable.name
+        }`;
+      case "environment.update.http_access":
+        return `${
+          payload.user.display_name
+        } updated HTTP Access settings on environment ${
+          payload.environment.title
+        }`;
+      case "environment.update.smtp":
+        return `${
+          payload.user.display_name
+        } updated SMTP settings on environment ${payload.environment.title}`;
+      case "environment.route.create":
+        return `${payload.user.display_name} added route ${
+          payload.route.route
+        }`;
+      case "environment.route.delete":
+        return `${payload.user.display_name} deleted route ${
+          payload.route.route
+        }`;
+      case "environment.route.update":
+        return `${payload.user.display_name} modified route ${
+          payload.route.route
+        }`;
+      case "environment.subscription.update":
         return `${payload.user.display_name} modified subscription`;
-      case 'project.create':
-        return `${payload.user.display_name} created a new project ${payload.outcome.title}`;
+      case "project.create":
+        return `${payload.user.display_name} created a new project ${
+          payload.outcome.title
+        }`;
     }
     return type;
   }

--- a/src/model/Deployment.js
+++ b/src/model/Deployment.js
@@ -1,8 +1,9 @@
-import Ressource from './Ressource';
-import { getConfig } from '../config';
+import Ressource from "./Ressource";
+import { getConfig } from "../config";
 
 const paramDefaults = {};
-const _url = '/projects/:projectId/environments/:environmentId/deployments/current';
+const _url =
+  "/projects/:projectId/environments/:environmentId/deployments/current";
 
 export default class Deployment extends Ressource {
   constructor(deployment, url) {
@@ -11,13 +12,18 @@ export default class Deployment extends Ressource {
     this.services = {};
     this.workers = {};
     this.routes = {};
-    this.id = '';
+    this.id = "";
   }
 
   static get(params = {}, customUrl) {
-    const { projectId, environmentId, ...queryParams} = params;
+    const { projectId, environmentId, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.get(customUrl || `${api_url}${_url}`, { projectId, environmentId }, paramDefaults, queryParams);
+    return super.get(
+      customUrl || `${api_url}${_url}`,
+      { projectId, environmentId },
+      paramDefaults,
+      queryParams
+    );
   }
 }

--- a/src/model/Domain.js
+++ b/src/model/Domain.js
@@ -1,28 +1,38 @@
-import Ressource from './Ressource';
-import { getConfig } from '../config';
+import Ressource from "./Ressource";
+import { getConfig } from "../config";
 
 const paramDefaults = {};
-const _url = '/projects/:projectId/domains';
+const _url = "/projects/:projectId/domains";
 
 export default class Domain extends Ressource {
   constructor(domain, url) {
-    super(url, paramDefaults, { }, domain, ['name', 'ssl']);
-    this.id = '';
-    this.name = '';
-    this._required = ['name'];
+    super(url, paramDefaults, {}, domain, ["name", "ssl"]);
+    this.id = "";
+    this.name = "";
+    this._required = ["name"];
   }
 
   static get(params, customUrl) {
     const { name, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.get(customUrl ? `${customUrl}/:name` : `${api_url}${_url}`, { name }, paramDefaults, queryParams);
+    return super.get(
+      customUrl ? `${customUrl}/:name` : `${api_url}${_url}`,
+      { name },
+      paramDefaults,
+      queryParams
+    );
   }
 
   static query(params, customUrl) {
     const { projectId, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.query(customUrl || `${api_url}${_url}`, { projectId }, paramDefaults, queryParams);
+    return super.query(
+      customUrl || `${api_url}${_url}`,
+      { projectId },
+      paramDefaults,
+      queryParams
+    );
   }
 }

--- a/src/model/Metrics.js
+++ b/src/model/Metrics.js
@@ -1,8 +1,8 @@
-import Ressource from './Ressource';
-import { getConfig } from '../config';
+import Ressource from "./Ressource";
+import { getConfig } from "../config";
 
 const paramDefaults = {};
-const _url = '/projects/:projectId/environments/:environmentId/metrics';
+const _url = "/projects/:projectId/environments/:environmentId/metrics";
 
 export default class Metrics extends Ressource {
   constructor(metrics, url) {
@@ -11,9 +11,14 @@ export default class Metrics extends Ressource {
   }
 
   static get(params = {}, customUrl) {
-    const { projectId, environmentId, ...queryParams} = params;
+    const { projectId, environmentId, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.get(customUrl || `${api_url}${_url}`, { projectId, environmentId }, paramDefaults, queryParams);
+    return super.get(
+      customUrl || `${api_url}${_url}`,
+      { projectId, environmentId },
+      paramDefaults,
+      queryParams
+    );
   }
 }

--- a/src/model/OrganizationMember.js
+++ b/src/model/OrganizationMember.js
@@ -1,10 +1,10 @@
-import Ressource from './Ressource';
-import { getConfig } from '../config';
+import Ressource from "./Ressource";
+import { getConfig } from "../config";
 
 const paramDefaults = {};
-const _url = '/platform/organizations/:organizationId/members';
+const _url = "/platform/organizations/:organizationId/members";
 
-const creatableField = ['user', 'role'];
+const creatableField = ["user", "role"];
 
 export default class OrganizationMember extends Ressource {
   constructor(organizationMember, url) {
@@ -19,22 +19,32 @@ export default class OrganizationMember extends Ressource {
       creatableField,
       creatableField
     );
-    this.user = '';// User id
-    this.role = '';
-    this.organizationId = '';
+    this.user = ""; // User id
+    this.role = "";
+    this.organizationId = "";
   }
 
   static get(params = {}, customUrl) {
     const { organizationId, id, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.get(customUrl || `${api_url}${_url}/:id`, { organizationId, id }, paramDefaults, queryParams);
+    return super.get(
+      customUrl || `${api_url}${_url}/:id`,
+      { organizationId, id },
+      paramDefaults,
+      queryParams
+    );
   }
 
   static query(params, customUrl) {
     const { organizationId, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.query(customUrl || `${api_url}${_url}`, { organizationId }, paramDefaults, queryParams);
+    return super.query(
+      customUrl || `${api_url}${_url}`,
+      { organizationId },
+      paramDefaults,
+      queryParams
+    );
   }
 }

--- a/src/model/Region.js
+++ b/src/model/Region.js
@@ -1,7 +1,7 @@
-import Ressource from './Ressource';
-import { getConfig } from '../config';
+import Ressource from "./Ressource";
+import { getConfig } from "../config";
 
-const url = '/platform/regions';
+const url = "/platform/regions";
 const paramDefaults = {};
 
 export default class Region extends Ressource {
@@ -11,13 +11,13 @@ export default class Region extends Ressource {
 
     super(`${account_url}${url}`, paramDefaults, { id }, region);
     this._queryUrl = Ressource.getQueryUrl(url);
-    this.id = '';
+    this.id = "";
     this.available = false;
-    this.endpoint = '';
-    this.label = '';
+    this.endpoint = "";
+    this.label = "";
     this.private = true;
-    this.provider = '';
-    this.zone = '';
+    this.provider = "";
+    this.zone = "";
   }
 
   static query(params) {

--- a/src/model/Route.js
+++ b/src/model/Route.js
@@ -1,22 +1,35 @@
-import Ressource from './Ressource';
-import { getConfig } from '../config';
+import Ressource from "./Ressource";
+import { getConfig } from "../config";
 
 const paramDefaults = {};
-const creatableAndModifiableField = ['route', 'to', 'type', 'upstream', 'cache'];
-const _url = '/projects/:projectId/environments/:environmentId/routes';
+const creatableAndModifiableField = [
+  "route",
+  "to",
+  "type",
+  "upstream",
+  "cache"
+];
+const _url = "/projects/:projectId/environments/:environmentId/routes";
 
 export default class Route extends Ressource {
   constructor(route, url) {
-    super(url, paramDefaults, { }, route, creatableAndModifiableField, creatableAndModifiableField);
-    this.id = '';
-    this.project = '';
-    this.environment = '';
+    super(
+      url,
+      paramDefaults,
+      {},
+      route,
+      creatableAndModifiableField,
+      creatableAndModifiableField
+    );
+    this.id = "";
+    this.project = "";
+    this.environment = "";
     this.route = {};
     this.cache = {};
     this.ssi = [];
-    this.upstream = '';
-    this.to = '';
-    this.type = '';
+    this.upstream = "";
+    this.to = "";
+    this.type = "";
   }
 
   static get(params, customUrl) {
@@ -24,13 +37,23 @@ export default class Route extends Ressource {
     const { api_url } = getConfig();
     const urlToCall = customUrl ? `${customUrl}/:id` : `${api_url}${_url}/:id`;
 
-    return super.get(urlToCall, { id, projectId, environmentId }, paramDefaults, queryParams);
+    return super.get(
+      urlToCall,
+      { id, projectId, environmentId },
+      paramDefaults,
+      queryParams
+    );
   }
 
   static query(params, customUrl) {
     const { projectId, environmentId, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.query(customUrl || `${api_url}${_url}`, { projectId, environmentId }, paramDefaults, queryParams);
+    return super.query(
+      customUrl || `${api_url}${_url}`,
+      { projectId, environmentId },
+      paramDefaults,
+      queryParams
+    );
   }
 }

--- a/src/model/Team.js
+++ b/src/model/Team.js
@@ -1,44 +1,61 @@
-import Ressource from './Ressource';
-import { getConfig } from '../config';
+import Ressource from "./Ressource";
+import { getConfig } from "../config";
 
-import TeamMember from './TeamMember';
+import TeamMember from "./TeamMember";
 
 const paramDefaults = {};
-const _url = '/platform/teams';
+const _url = "/platform/teams";
 
-const creatableField = ['name', 'parent', 'id'];
-const modifiableField = ['name'];
+const creatableField = ["name", "parent", "id"];
+const modifiableField = ["name"];
 
 export default class Team extends Ressource {
   constructor(team, url) {
     const { api_url } = getConfig();
 
-    super(url || `${api_url}${_url}`, paramDefaults, {}, team, creatableField, modifiableField);
-    this.id = '';
-    this.name = '';
-    this.parent = '';// teamId or null
-    this.organization = '';// organizationId
+    super(
+      url || `${api_url}${_url}`,
+      paramDefaults,
+      {},
+      team,
+      creatableField,
+      modifiableField
+    );
+    this.id = "";
+    this.name = "";
+    this.parent = ""; // teamId or null
+    this.organization = ""; // organizationId
   }
 
   static get(params = {}, customUrl) {
     const { id, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.get(customUrl || `${api_url}${_url}/:id`, { id }, paramDefaults, queryParams);
+    return super.get(
+      customUrl || `${api_url}${_url}/:id`,
+      { id },
+      paramDefaults,
+      queryParams
+    );
   }
 
   static query(params, customUrl) {
     const { api_url } = getConfig();
 
-    return super.query(customUrl || `${api_url}${_url}`, {}, paramDefaults, params);
+    return super.query(
+      customUrl || `${api_url}${_url}`,
+      {},
+      paramDefaults,
+      params
+    );
   }
 
   getMembers() {
-    return TeamMember.query({ teamId: this.id});
+    return TeamMember.query({ teamId: this.id });
   }
 
   addMember(member) {
-    const teamMember = new TeamMember({ ...member, teamId: this.id});
+    const teamMember = new TeamMember({ ...member, teamId: this.id });
 
     return teamMember.save();
   }
@@ -47,7 +64,7 @@ export default class Team extends Ressource {
     if (this.hasLink(rel)) {
       return super.getLink(rel, absolute);
     }
-    if (rel === 'self') {
+    if (rel === "self") {
       const { api_url } = getConfig();
 
       return `${api_url}${_url}/:id`;

--- a/src/model/TeamMember.js
+++ b/src/model/TeamMember.js
@@ -1,31 +1,48 @@
-import Ressource from './Ressource';
-import { getConfig } from '../config';
+import Ressource from "./Ressource";
+import { getConfig } from "../config";
 
 const paramDefaults = {};
-const _url = '/platform/teams/:teamId/members';
+const _url = "/platform/teams/:teamId/members";
 
-const creatableField = ['role'];
+const creatableField = ["role"];
 
 export default class TeamMember extends Ressource {
   constructor(teamMember, url) {
     const { teamId } = teamMember;
     const { api_url } = getConfig();
 
-    super(url || `${api_url}${_url}`, paramDefaults, { teamId }, teamMember, creatableField, creatableField);
-    this.user = '';// userId
+    super(
+      url || `${api_url}${_url}`,
+      paramDefaults,
+      { teamId },
+      teamMember,
+      creatableField,
+      creatableField
+    );
+    this.user = ""; // userId
   }
 
   static get(params = {}, customUrl) {
     const { teamId, id, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.get(customUrl || `${api_url}${_url}/:id`, { teamId, id }, paramDefaults, queryParams);
+    return super.get(
+      customUrl || `${api_url}${_url}/:id`,
+      { teamId, id },
+      paramDefaults,
+      queryParams
+    );
   }
 
   static query(params, customUrl) {
     const { teamId, ...queryParams } = params;
     const { api_url } = getConfig();
 
-    return super.query(customUrl || `${api_url}${_url}`, { teamId }, paramDefaults, queryParams);
+    return super.query(
+      customUrl || `${api_url}${_url}`,
+      { teamId },
+      paramDefaults,
+      queryParams
+    );
   }
 }


### PR DESCRIPTION
Seems that some files were not following our eslint/prettier rules.

Also removes an unnecessary configuration property on `.eslintrc` reported by `npm run eslint`.

All the changes below with exception of the ones on `.eslintrc` were automatically performed by `prettier --write "./**/*.js"`