### PR TITLE
refactor: removes `/api`, `/api/platform` and `/api/v1` slugs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,5 @@
 const DEFAULT_ACCOUNT_URL = "https://accounts.platform.sh";
-const DEFAULT_API_URL = "https://api.platform.sh/api";
+const DEFAULT_API_URL = "https://api.platform.sh";
 
 const getConfigDefault = (
   baseUrl = DEFAULT_ACCOUNT_URL,
@@ -7,7 +7,7 @@ const getConfigDefault = (
 ) => ({
   provider: "cg",
   client_id: "platform@d4tobd5qpizwa.eu.platform.sh",
-  account_url: `${baseUrl}/api`,
+  account_url: `${baseUrl}`,
   api_url,
   authentication_url: baseUrl,
   scope: [],

--- a/src/index.js
+++ b/src/index.js
@@ -66,11 +66,9 @@ export default class Client {
       }
       const { account_url } = getConfig();
 
-      return request(`${account_url}/platform/projects/${id}`, "GET").then(
-        result => {
-          return result.endpoint || false;
-        }
-      );
+      return request(`${account_url}/projects/${id}`, "GET").then(result => {
+        return result.endpoint || false;
+      });
     });
   }
 
@@ -463,7 +461,7 @@ export default class Client {
     if (country_code) query.country_code = country_code;
     const { api_url } = getConfig();
 
-    return request(`${api_url}/v1/subscriptions/estimate`, "GET", query);
+    return request(`${api_url}/subscriptions/estimate`, "GET", query);
   }
 
   /**
@@ -629,7 +627,7 @@ export default class Client {
    */
   getCardOnFile() {
     const { api_url } = getConfig();
-    const card = request(`${api_url}/platform/cardonfile`, "GET");
+    const card = request(`${api_url}/cardonfile`, "GET");
     return card;
   }
 
@@ -731,7 +729,7 @@ export default class Client {
   async updateUserProfile(id, data) {
     const { api_url } = getConfig();
     const updatedProfile = await request(
-      `${api_url}/platform/profiles/${id}`,
+      `${api_url}/profiles/${id}`,
       "PATCH",
       data
     );
@@ -746,7 +744,7 @@ export default class Client {
    */
   getSetupRegistry() {
     const { api_url } = getConfig();
-    return request(`${api_url}/platform/setup/registry`, "POST").then(data => {
+    return request(`${api_url}/setup/registry`, "POST").then(data => {
       return typeof data === "undefined"
         ? undefined
         : Object.entries(data).reduce((items, [key, value]) => {
@@ -783,7 +781,7 @@ export default class Client {
    */
   getSetupRegistry() {
     const { api_url } = getConfig();
-    return request(`${api_url}/platform/setup/registry`, "POST").then(data => {
+    return request(`${api_url}/setup/registry`, "POST").then(data => {
       return typeof data === "undefined"
         ? undefined
         : Object.entries(data).reduce((items, [key, value]) => {
@@ -834,7 +832,7 @@ export default class Client {
     const { api_url } = getConfig();
 
     const user = await request(
-      `${api_url}/v1/profiles?filter[username]=${username}`
+      `${api_url}/profiles?filter[username]=${username}`
     );
 
     return new entities.AccountsProfile(user.profiles[0]);

--- a/src/model/Account.js
+++ b/src/model/Account.js
@@ -1,7 +1,7 @@
 import Ressource from "./Ressource";
 import { getConfig } from "../config";
 
-const url = "/platform/users/:id";
+const url = "/users/:id";
 const paramDefaults = {};
 
 export default class Account extends Ressource {

--- a/src/model/AccountsProfile.js
+++ b/src/model/AccountsProfile.js
@@ -3,7 +3,7 @@ import { getConfig } from "../config";
 import request from "../api";
 import _urlParser from "../urlParser";
 
-const url = "/platform/profiles/:id";
+const url = "/profiles/:id";
 const paramDefaults = {};
 const createableField = [
   "id",
@@ -90,7 +90,7 @@ export default class AccountsProfile extends Ressource {
     const { api_url } = getConfig();
 
     const user = await request(
-      `${api_url}/v1/profiles?filter[username]=${username}`
+      `${api_url}/profiles?filter[username]=${username}`
     );
 
     return new AccountsProfile(user.profiles[0]);
@@ -98,11 +98,11 @@ export default class AccountsProfile extends Ressource {
 
   static updateProfilePicture(userId, picture) {
     const { api_url } = getConfig();
-    return request(`${api_url}/v1/profile/${userId}/picture`, "POST", picture);
+    return request(`${api_url}/profile/${userId}/picture`, "POST", picture);
   }
 
   static async deleteProfilePicture(userId) {
     const { api_url } = getConfig();
-    return request(`${api_url}/v1/profile/${userId}/picture`, "DELETE");
+    return request(`${api_url}/profile/${userId}/picture`, "DELETE");
   }
 }

--- a/src/model/Address.js
+++ b/src/model/Address.js
@@ -2,7 +2,7 @@ import Ressource from "./Ressource";
 import { getConfig } from "../config";
 import _urlParser from "../urlParser";
 
-const url = "/v1/profiles/:id/address";
+const url = "/profiles/:id/address";
 const paramDefaults = {};
 
 export default class Address extends Ressource {

--- a/src/model/Comment.js
+++ b/src/model/Comment.js
@@ -2,7 +2,7 @@ import Ressource from "./Ressource";
 import { getConfig } from "../config";
 import request from "../api";
 
-const url = "/v1/comments";
+const url = "/comments";
 const paramDefaults = {};
 
 export default class Comment extends Ressource {

--- a/src/model/Me.js
+++ b/src/model/Me.js
@@ -2,7 +2,7 @@ import User from "./User";
 import Ressource from "./Ressource";
 import { getConfig } from "../config";
 
-const url = "/platform/me";
+const url = "/me";
 const paramDefaults = {};
 const modifiableField = [
   "picture",
@@ -46,7 +46,7 @@ export default class Me extends User {
   async update(data) {
     const { api_url } = getConfig();
 
-    const result = await super.update(data, `${api_url}/platform/profiles/:id`);
+    const result = await super.update(data, `${api_url}/profiles/:id`);
 
     return new Me(result.data); // Account API does not return a Result
   }

--- a/src/model/Order.js
+++ b/src/model/Order.js
@@ -1,7 +1,7 @@
 import Ressource from "./Ressource";
 import { getConfig } from "../config";
 
-const url = "/v1/orders/:id";
+const url = "/orders/:id";
 const paramDefaults = {};
 
 export default class Order extends Ressource {

--- a/src/model/PaymentSource.js
+++ b/src/model/PaymentSource.js
@@ -4,7 +4,7 @@ import Result from "./Result";
 import _urlParser from "../urlParser";
 import request from "../api";
 
-const url = "/platform/payment_source";
+const url = "/payment_source";
 const paramDefaults = {};
 const creatableField = ["type", "token", "email"];
 

--- a/src/model/Region.js
+++ b/src/model/Region.js
@@ -1,7 +1,7 @@
 import Ressource from "./Ressource";
 import { getConfig } from "../config";
 
-const url = "/platform/regions";
+const url = "/regions";
 const paramDefaults = {};
 
 export default class Region extends Ressource {

--- a/src/model/SetupConfig.js
+++ b/src/model/SetupConfig.js
@@ -3,7 +3,7 @@ import { getConfig } from "../config";
 import _urlParser from "../urlParser";
 import request from "../api";
 
-const _url = "/platform/setup/config";
+const _url = "/setup/config";
 const paramDefaults = {};
 
 export default class SetupConfig extends Ressource {

--- a/src/model/SetupRegistry.js
+++ b/src/model/SetupRegistry.js
@@ -3,9 +3,9 @@ import { getConfig } from "../config";
 import _urlParser from "../urlParser";
 import request from "../api";
 
-const _url = "/platform/setup/registry";
+const _url = "/setup/registry";
 const paramDefaults = {};
-// /api/platform/setup/registry\?service\=redis-persistent
+// /setup/registry\?service\=redis-persistent
 
 export default class SetupRegistry extends Ressource {
   constructor(registry, url = `${_url}?service=:name`, modifiableField = []) {

--- a/src/model/SshKey.js
+++ b/src/model/SshKey.js
@@ -5,7 +5,7 @@ import _urlParser from "../urlParser";
 import { getConfig } from "../config";
 
 const paramDefaults = {};
-const url = "/v1/ssh_keys/:id";
+const url = "/ssh_keys/:id";
 
 export default class SshKey extends Ressource {
   constructor(sshKey) {

--- a/src/model/Subscription.js
+++ b/src/model/Subscription.js
@@ -20,7 +20,7 @@ const creatableField = [
 
 const modifiableField = ["plan", "environments", "storage", "big_dev"];
 
-const url = "/v1/subscriptions/:id";
+const url = "/subscriptions/:id";
 const STATUS_ACTIVE = "active";
 const STATUS_REQUESTED = "requested";
 const STATUS_PROVISIONING = "provisioning";
@@ -177,7 +177,7 @@ export default class Subscription extends Ressource {
    */
   getOwner() {
     const id = this.owner;
-    const url = this.makeAbsoluteUrl("/api/users", this.getLink("project"));
+    const url = this.makeAbsoluteUrl("/users", this.getLink("project"));
 
     return Account.get({ id }, url);
   }

--- a/src/model/Team.js
+++ b/src/model/Team.js
@@ -4,7 +4,7 @@ import { getConfig } from "../config";
 import TeamMember from "./TeamMember";
 
 const paramDefaults = {};
-const _url = "/platform/teams";
+const _url = "/teams";
 
 const creatableField = ["name", "parent", "id"];
 const modifiableField = ["name"];

--- a/src/model/TeamMember.js
+++ b/src/model/TeamMember.js
@@ -2,7 +2,7 @@ import Ressource from "./Ressource";
 import { getConfig } from "../config";
 
 const paramDefaults = {};
-const _url = "/platform/teams/:teamId/members";
+const _url = "/teams/:teamId/members";
 
 const creatableField = ["role"];
 

--- a/src/model/Ticket.js
+++ b/src/model/Ticket.js
@@ -2,7 +2,7 @@ import Ressource from "./Ressource";
 import { getConfig } from "../config";
 import request from "../api";
 
-const url = "/v1/tickets";
+const url = "/tickets";
 const paramDefaults = {};
 
 export default class Ticket extends Ressource {
@@ -23,14 +23,14 @@ export default class Ticket extends Ressource {
 
   static getAttachments(ticketId) {
     const { api_url } = getConfig();
-    const url = `/v1/comments/${ticketId}/description`;
+    const url = `/comments/${ticketId}/description`;
 
     return super.get(`${api_url}${url}`, {}, paramDefaults, {});
   }
 
   static getAllAttachments(ticketId) {
     const { api_url } = getConfig();
-    const url = `/v1/comments/${ticketId}/attachments`;
+    const url = `/comments/${ticketId}/attachments`;
 
     return request(`${api_url}${url}`, "GET");
   }

--- a/src/model/TicketPriority.js
+++ b/src/model/TicketPriority.js
@@ -1,7 +1,7 @@
 import Ressource from "./Ressource";
 import { getConfig } from "../config";
 
-const url = "/v1/tickets/priority";
+const url = "/tickets/priority";
 const paramDefaults = {};
 
 export default class TicketPriority extends Ressource {

--- a/src/model/User.js
+++ b/src/model/User.js
@@ -1,7 +1,7 @@
 import Ressource from "./Ressource";
 import { getConfig } from "../config";
 
-const _url = "/api/users";
+const _url = "/users";
 const paramDefaults = {};
 
 export default class User extends Ressource {

--- a/src/model/Voucher.js
+++ b/src/model/Voucher.js
@@ -1,7 +1,7 @@
 import Ressource from "./Ressource";
 import { getConfig } from "../config";
 
-const url = "/v1/vouchers";
+const url = "/vouchers";
 const paramDefaults = {};
 
 export default class Voucher extends Ressource {

--- a/test/Account.spec.js
+++ b/test/Account.spec.js
@@ -19,7 +19,7 @@ describe("Account", () => {
   });
 
   it("Get account", done => {
-    fetchMock.mock(`${account_url}/platform/users/1`, {
+    fetchMock.mock(`${account_url}/users/1`, {
       id: 1,
       email: "test@test.com"
     });
@@ -40,10 +40,7 @@ describe("Account", () => {
       { id: 4, email: "test4" }
     ];
 
-    fetchMock.mock(
-      `${account_url}/platform/users?id=1&id=2&id=3&id=4`,
-      accounts
-    );
+    fetchMock.mock(`${account_url}/users?id=1&id=2&id=3&id=4`, accounts);
 
     Account.query({ id: [1, 2, 3, 4] }).then(accounts => {
       assert.equal(accounts.length, 4);

--- a/test/AccountsProfile.spec.js
+++ b/test/AccountsProfile.spec.js
@@ -19,7 +19,7 @@ describe("AccountsProfile", () => {
   });
 
   it("Get AccountsProfile", done => {
-    fetchMock.mock(`${api_url}/platform/profiles/1`, {
+    fetchMock.mock(`${api_url}/profiles/1`, {
       id: 1,
       display_name: "test",
       email: "test@test.com",
@@ -38,7 +38,7 @@ describe("AccountsProfile", () => {
   });
 
   it("GetUserIdFromUsername AccountsProfile", done => {
-    fetchMock.mock(`${api_url}/v1/profiles?filter[username]=alice`, {
+    fetchMock.mock(`${api_url}/profiles?filter[username]=alice`, {
       profiles: [
         {
           id: 1,
@@ -62,7 +62,7 @@ describe("AccountsProfile", () => {
 
   it("Update AccountsProfile", done => {
     fetchMock.mock(
-      `${api_url}/platform/profiles/1`,
+      `${api_url}/profiles/1`,
       {
         display_name: "test",
         username: "alice"

--- a/test/Client.spec.js
+++ b/test/Client.spec.js
@@ -11,7 +11,7 @@ const _fetch = (url, data, ...params) =>
 
 describe("Client", () => {
   let client;
-  const { authentication_url, api_url } = getConfig();
+  const { authentication_url, api_url, account_url } = getConfig();
 
   beforeEach(function() {
     fetchMock.mock(`${authentication_url}/oauth2/token`, {
@@ -25,14 +25,14 @@ describe("Client", () => {
   });
 
   it("Get current Account", done => {
-    fetchMock.mock(`${api_url}/platform/me`, {
+    fetchMock.mock(`${api_url}/me`, {
       id: 1,
       display_name: "test",
       projects: [
         {
           id: "ffzefzef",
           name: "greatProject",
-          endpoint: "http://test.com/api/projects/ffzefzef"
+          endpoint: "http://test.com/projects/ffzefzef"
         }
       ]
     });
@@ -46,7 +46,7 @@ describe("Client", () => {
     fetchMock.mock(`${api_url}/projects/ffzefzef3`, {
       id: "ffzefzef1",
       title: "greatProject",
-      endpoint: "http://test.com/api/projects/ffzefzef1"
+      endpoint: "http://test.com/projects/ffzefzef1"
     });
     client.getProject("ffzefzef3").then(project => {
       assert.equal(project.title, "greatProject");
@@ -56,15 +56,12 @@ describe("Client", () => {
   });
 
   it("Get environments", done => {
-    fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/environments",
-      [
-        {
-          id: 1,
-          name: "bestEnv"
-        }
-      ]
-    );
+    fetchMock.mock(`${api_url}/projects/ffzefzef3/environments`, [
+      {
+        id: 1,
+        name: "bestEnv"
+      }
+    ]);
     client.getEnvironments("ffzefzef3").then(environments => {
       assert.equal(environments.length, 1);
       assert.equal(environments[0].id, 1);
@@ -75,13 +72,10 @@ describe("Client", () => {
   });
 
   it("Get environment", done => {
-    fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/environments/1",
-      {
-        id: 1,
-        name: "bestEnv"
-      }
-    );
+    fetchMock.mock(`${api_url}/projects/ffzefzef3/environments/1`, {
+      id: 1,
+      name: "bestEnv"
+    });
     client.getEnvironment("ffzefzef3", "1").then(environment => {
       assert.equal(environment.id, 1);
       assert.equal(environment.name, "bestEnv");
@@ -91,15 +85,12 @@ describe("Client", () => {
   });
 
   it("Get activities", done => {
-    fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/environments/1/activities",
-      [
-        {
-          id: 1,
-          completion_percent: 50
-        }
-      ]
-    );
+    fetchMock.mock(`${api_url}/projects/ffzefzef3/environments/1/activities`, [
+      {
+        id: 1,
+        completion_percent: 50
+      }
+    ]);
     client.getEnvironmentActivities("ffzefzef3", "1").then(activities => {
       assert.equal(activities.length, 1);
       assert.equal(activities[0].id, 1);
@@ -110,15 +101,12 @@ describe("Client", () => {
   });
 
   it("Get certificates", done => {
-    fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/certificates",
-      [
-        {
-          id: 1,
-          key: "test"
-        }
-      ]
-    );
+    fetchMock.mock(`${api_url}/projects/ffzefzef3/certificates`, [
+      {
+        id: 1,
+        key: "test"
+      }
+    ]);
     client.getCertificates("ffzefzef3").then(certificates => {
       assert.equal(certificates.length, 1);
       assert.equal(certificates[0].id, 1);
@@ -129,11 +117,7 @@ describe("Client", () => {
   });
 
   it("Add certificates", done => {
-    fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/certificates",
-      {},
-      "POST"
-    );
+    fetchMock.mock(`${api_url}/projects/ffzefzef3/certificates`, {}, "POST");
 
     client
       .addCertificate("ffzefzef3", "certif", "key", "chain")
@@ -144,10 +128,9 @@ describe("Client", () => {
   });
 
   it("Get domains", done => {
-    fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/domains?limit=2",
-      [{ id: 1 }]
-    );
+    fetchMock.mock(`${api_url}/projects/ffzefzef3/domains?limit=2`, [
+      { id: 1 }
+    ]);
 
     client.getDomains("ffzefzef3", 2).then(domains => {
       assert.equal(domains[0].id, 1);
@@ -157,10 +140,9 @@ describe("Client", () => {
   });
 
   it("Get environment users", done => {
-    fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/environments/1/access",
-      [{ id: 1 }]
-    );
+    fetchMock.mock(`${api_url}/projects/ffzefzef3/environments/1/access`, [
+      { id: 1 }
+    ]);
 
     client.getEnvironmentUsers("ffzefzef3", "1").then(users => {
       assert.equal(users[0].id, 1);
@@ -170,9 +152,7 @@ describe("Client", () => {
   });
 
   it("Get project users", done => {
-    fetchMock.mock("https://api.platform.sh/api/projects/ffzefzef3/access", [
-      { id: 1 }
-    ]);
+    fetchMock.mock(`${api_url}/projects/ffzefzef3/access`, [{ id: 1 }]);
 
     client.getProjectUsers("ffzefzef3").then(users => {
       assert.equal(users[0].id, 1);
@@ -182,15 +162,12 @@ describe("Client", () => {
   });
 
   it("Get variables", done => {
-    fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/variables?limit=1",
-      [
-        {
-          id: 1,
-          name: "theVariableName"
-        }
-      ]
-    );
+    fetchMock.mock(`${api_url}/projects/ffzefzef3/variables?limit=1`, [
+      {
+        id: 1,
+        name: "theVariableName"
+      }
+    ]);
 
     client.getProjectVariables("ffzefzef3", 1).then(activities => {
       assert.equal(activities[0].constructor.name, "ProjectLevelVariable");
@@ -201,7 +178,7 @@ describe("Client", () => {
 
   it("Get environment variables", done => {
     fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/environments/1/variables?limit=1",
+      `${api_url}/projects/ffzefzef3/environments/1/variables?limit=1`,
       [
         {
           id: 1,
@@ -218,15 +195,12 @@ describe("Client", () => {
   });
 
   it("Get routes", done => {
-    fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/environments/1/routes",
-      [
-        {
-          id: 1,
-          project: "ffzefzef3"
-        }
-      ]
-    );
+    fetchMock.mock(`${api_url}/projects/ffzefzef3/environments/1/routes`, [
+      {
+        id: 1,
+        project: "ffzefzef3"
+      }
+    ]);
 
     client.getRoutes("ffzefzef3", 1).then(routes => {
       assert.equal(routes[0].constructor.name, "Route");
@@ -237,7 +211,7 @@ describe("Client", () => {
 
   it("Get environment metrics", done => {
     fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/environments/1/metrics?q=test",
+      `${api_url}/projects/ffzefzef3/environments/1/metrics?q=test`,
       { results: 1 }
     );
 
@@ -249,7 +223,7 @@ describe("Client", () => {
   });
 
   it("Get ssh keys", done => {
-    fetchMock.mock(`${api_url}/platform/me`, {
+    fetchMock.mock(`${api_url}/me`, {
       id: 1,
       name: "test",
       ssh_keys: [
@@ -266,7 +240,7 @@ describe("Client", () => {
   });
 
   it("Get ssh key", done => {
-    fetchMock.mock(`${api_url}/v1/ssh_keys/theId`, {
+    fetchMock.mock(`${api_url}/ssh_keys/theId`, {
       changed: "2017-03-13T17:38:49+01:00"
     });
     client.getSshKey({ id: "theId" }).then(sshkey => {
@@ -278,7 +252,7 @@ describe("Client", () => {
 
   it("Add a bad ssh key", done => {
     fetchMock.mock(
-      `${api_url}/v1/ssh_keys`,
+      `${api_url}/ssh_keys`,
       {
         changed: "2017-03-13T17:38:49+01:00"
       },
@@ -292,7 +266,7 @@ describe("Client", () => {
 
   it("Add a ssh key", done => {
     fetchMock.mock(
-      `${api_url}/v1/ssh_keys`,
+      `${api_url}/ssh_keys`,
       {
         changed: "2017-03-13T17:38:49+01:00"
       },
@@ -319,7 +293,7 @@ describe("Client", () => {
 
   it("Create subscription", done => {
     fetchMock.mock(
-      `${api_url}/v1/subscriptions`,
+      `${api_url}/subscriptions`,
       {
         project_region: "region"
       },
@@ -343,7 +317,7 @@ describe("Client", () => {
   });
 
   it("Get subscription", done => {
-    fetchMock.mock(`${api_url}/v1/subscriptions/1`, {
+    fetchMock.mock(`${api_url}/subscriptions/1`, {
       project_region: "region"
     });
     client.getSubscription("1").then(subscription => {
@@ -354,7 +328,7 @@ describe("Client", () => {
   });
 
   it("Get subscriptions", done => {
-    fetchMock.mock(`${api_url}/v1/subscriptions`, {
+    fetchMock.mock(`${api_url}/subscriptions`, {
       subscriptions: [
         {
           project_region: "region"
@@ -371,7 +345,7 @@ describe("Client", () => {
 
   it("Get subscriptions with filters", done => {
     fetchMock.mock(
-      `${api_url}/v1/subscriptions?filter[project_title][value]=Demo&filter[project_title][operator]=Contains`, //eslint-disable-line
+      `${api_url}/subscriptions?filter[project_title][value]=Demo&filter[project_title][operator]=Contains`, //eslint-disable-line
       {
         subscriptions: [
           {
@@ -394,7 +368,7 @@ describe("Client", () => {
 
   it("Get subscription estimate", done => {
     fetchMock.mock(
-      `${api_url}/v1/subscriptions/estimate?plan=plan&storage=storage&environments=environments&user_licenses=users`,
+      `${api_url}/subscriptions/estimate?plan=plan&storage=storage&environments=environments&user_licenses=users`,
       {
         key: "value"
       }
@@ -409,7 +383,7 @@ describe("Client", () => {
 
   it("Get current deployment informations", done => {
     fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/environments/1/deployments/current",
+      `${api_url}/projects/ffzefzef3/environments/1/deployments/current`,
       {
         webapps: {
           php: {}
@@ -423,7 +397,7 @@ describe("Client", () => {
   });
 
   it("Get organizations", done => {
-    fetchMock.mock("https://api.platform.sh/api/organizations", [
+    fetchMock.mock(`${api_url}/organizations`, [
       {
         id: "1",
         name: "org1",
@@ -441,7 +415,7 @@ describe("Client", () => {
   });
 
   it("Get organization", done => {
-    fetchMock.mock("https://api.platform.sh/api/organizations/1", {
+    fetchMock.mock(`${api_url}/organizations/1`, {
       id: "1",
       name: "org1",
       label: "the organization",
@@ -457,7 +431,7 @@ describe("Client", () => {
   });
 
   it("Get teams", done => {
-    fetchMock.mock("https://api.platform.sh/api/platform/me", {
+    fetchMock.mock(`${api_url}/me`, {
       teams: [
         {
           id: "1",
@@ -476,7 +450,7 @@ describe("Client", () => {
   });
 
   it("Get team", done => {
-    fetchMock.mock("https://api.platform.sh/api/platform/teams/1", {
+    fetchMock.mock(`${api_url}/teams/1`, {
       id: "1",
       name: "team1",
       parent: "2"
@@ -491,7 +465,7 @@ describe("Client", () => {
   });
 
   it("Create team", done => {
-    fetchMock.mock("https://api.platform.sh/api/platform/teams", {}, "POST");
+    fetchMock.mock(`${api_url}/teams`, {}, "POST");
     client.createTeam({ name: "team1" }).then(result => {
       assert.equal(result.constructor.name, "Result");
       done();
@@ -499,7 +473,7 @@ describe("Client", () => {
   });
 
   it("Create organization", done => {
-    fetchMock.mock("https://api.platform.sh/api/organizations", {}, "POST");
+    fetchMock.mock(`${api_url}/organizations`, {}, "POST");
     client.createOrganization({ name: "organization1" }).then(result => {
       assert.equal(result.constructor.name, "Result");
       done();
@@ -507,7 +481,7 @@ describe("Client", () => {
   });
 
   it("Get regions", done => {
-    fetchMock.mock("https://accounts.platform.sh/api/platform/regions", [
+    fetchMock.mock(`${account_url}/regions`, [
       {
         available: true,
         endpoint: "https://staging.plat.farm/api",
@@ -530,7 +504,7 @@ describe("Client", () => {
   });
 
   it("Get account", done => {
-    fetchMock.mock("https://accounts.platform.sh/api/platform/users/test", {
+    fetchMock.mock(`${account_url}/users/test`, {
       id: "test",
       display_name: "testdn"
     });
@@ -542,7 +516,7 @@ describe("Client", () => {
   });
 
   it("Get orders", done => {
-    fetchMock.mock(`${api_url}/v1/orders?filter[owner]=1`, {
+    fetchMock.mock(`${api_url}/orders?filter[owner]=1`, {
       commerce_order: [
         {
           id: "803635",
@@ -593,7 +567,7 @@ describe("Client", () => {
       _links: {
         self: {
           title: "Self",
-          href: "http://accounts.psh.local/api/platform/orders"
+          href: "http://accounts.psh.local/orders"
         }
       }
     });
@@ -606,7 +580,7 @@ describe("Client", () => {
 
   it("Get order", done => {
     fetchMock.mock(
-      `${api_url}/v1/orders/1`,
+      `${api_url}/orders/1`,
       JSON.stringify({
         id: "31619",
         status: "invoiced",
@@ -731,7 +705,7 @@ describe("Client", () => {
 
   describe("Profile pictures", () => {
     it("Delete", async () => {
-      _fetch(`${api_url}/v1/profile/1/picture`, null, "DELETE");
+      _fetch(`${api_url}/profile/1/picture`, null, "DELETE");
 
       try {
         await client.deleteProfilePicture("1");
@@ -742,7 +716,7 @@ describe("Client", () => {
     });
 
     it("Update", async () => {
-      _fetch(`${api_url}/v1/profile/1/picture`, { url: "xyz" }, "POST");
+      _fetch(`${api_url}/profile/1/picture`, { url: "xyz" }, "POST");
 
       const response = await client.updateProfilePicture(1, {});
 

--- a/test/Environment.spec.js
+++ b/test/Environment.spec.js
@@ -17,15 +17,12 @@ describe("Environment", () => {
   });
 
   it("Get environments", done => {
-    fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/environments",
-      [
-        {
-          id: 1,
-          name: "thevar"
-        }
-      ]
-    );
+    fetchMock.mock("https://api.platform.sh/projects/ffzefzef3/environments", [
+      {
+        id: 1,
+        name: "thevar"
+      }
+    ]);
 
     Environment.query({
       projectId: "ffzefzef3"
@@ -38,7 +35,7 @@ describe("Environment", () => {
 
   it("Get environment", done => {
     fetchMock.mock(
-      "https://api.platform.sh/api/projects/ffzefzef3/environments/1",
+      "https://api.platform.sh/projects/ffzefzef3/environments/1",
       {
         id: 1,
         name: "thevar"
@@ -56,7 +53,7 @@ describe("Environment", () => {
 
   it("Get variable", done => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/environments/1/variables/1",
+      "https://test.com/projects/ffzefzef3/environments/1/variables/1",
       {
         id: 1,
         name: "thevar"
@@ -66,12 +63,12 @@ describe("Environment", () => {
       {
         _links: {
           "#manage-variables": {
-            href: "/api/projects/ffzefzef3/environments/1/variables"
+            href: "/projects/ffzefzef3/environments/1/variables"
           }
         },
         id: 1
       },
-      "https://test.com/api/projects/ffzefzef3/environments"
+      "https://test.com/projects/ffzefzef3/environments"
     );
 
     environment.getVariable(1).then(variable => {
@@ -82,7 +79,7 @@ describe("Environment", () => {
 
   it("Delete environment", done => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/environments/1",
+      "https://test.com/projects/ffzefzef3/environments/1",
       {},
       "DELETE"
     );
@@ -90,16 +87,16 @@ describe("Environment", () => {
       {
         _links: {
           "#manage-variables": {
-            href: "/api/projects/ffzefzef3/environments/1/variables"
+            href: "/projects/ffzefzef3/environments/1/variables"
           },
           "#delete": {
-            href: "/api/projects/ffzefzef3/environments/1"
+            href: "/projects/ffzefzef3/environments/1"
           }
         },
         id: 1,
         status: "inactive"
       },
-      "https://test.com/api/projects/ffzefzef3/environments/1"
+      "https://test.com/projects/ffzefzef3/environments/1"
     );
 
     environment.delete().then(() => {
@@ -109,7 +106,7 @@ describe("Environment", () => {
 
   it("Activate environment", done => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/environments/1/activate",
+      "https://test.com/projects/ffzefzef3/environments/1/activate",
       {
         _embedded: {
           activities: [
@@ -118,7 +115,7 @@ describe("Environment", () => {
               _links: {
                 self: {
                   href:
-                    "https://admin.local.c-g.io/api/projects/test_project/activities/kwfj7emjcltpm",
+                    "https://admin.local.c-g.io/projects/test_project/activities/kwfj7emjcltpm",
                   meta: {
                     get: {
                       responses: {
@@ -254,19 +251,19 @@ describe("Environment", () => {
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3/environments/1"
+            href: "/projects/ffzefzef3/environments/1"
           },
           "#manage-variables": {
-            href: "/api/projects/ffzefzef3/environments/1/variables"
+            href: "/projects/ffzefzef3/environments/1/variables"
           },
           "#activate": {
-            href: "/api/projects/ffzefzef3/environments/1/activate"
+            href: "/projects/ffzefzef3/environments/1/activate"
           }
         },
         id: 1,
         status: "inactive"
       },
-      "https://test.com/api/projects/ffzefzef3/environments/1"
+      "https://test.com/projects/ffzefzef3/environments/1"
     );
 
     environment.activate().then(() => {
@@ -276,7 +273,7 @@ describe("Environment", () => {
 
   it("Deactivate environment", done => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/environments/1/deactivate",
+      "https://test.com/projects/ffzefzef3/environments/1/deactivate",
       {
         _embedded: {
           activities: [
@@ -285,7 +282,7 @@ describe("Environment", () => {
               _links: {
                 self: {
                   href:
-                    "https://admin.local.c-g.io/api/projects/test_project/activities/kwfj7emjcltpm",
+                    "https://admin.local.c-g.io/projects/test_project/activities/kwfj7emjcltpm",
                   meta: {
                     get: {
                       responses: {
@@ -421,19 +418,19 @@ describe("Environment", () => {
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3/environments/1"
+            href: "/projects/ffzefzef3/environments/1"
           },
           "#manage-variables": {
-            href: "/api/projects/ffzefzef3/environments/1/variables"
+            href: "/projects/ffzefzef3/environments/1/variables"
           },
           "#deactivate": {
-            href: "/api/projects/ffzefzef3/environments/1/deactivate"
+            href: "/projects/ffzefzef3/environments/1/deactivate"
           }
         },
         id: 1,
         status: "active"
       },
-      "https://test.com/api/projects/ffzefzef3/environments/1"
+      "https://test.com/projects/ffzefzef3/environments/1"
     );
 
     environment.deactivate().then(() => {
@@ -442,23 +439,20 @@ describe("Environment", () => {
   });
 
   it("Get metrics", done => {
-    fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/environments/metrics",
-      {
-        results: {}
-      }
-    );
+    fetchMock.mock("https://test.com/projects/ffzefzef3/environments/metrics", {
+      results: {}
+    });
 
     const environment = new Environment(
       {
         _links: {
           self: {
-            href: "https://test.com/api/projects/ffzefzef3/environments"
+            href: "https://test.com/projects/ffzefzef3/environments"
           }
         },
         id: 1
       },
-      "https://test.com/api/projects/ffzefzef3/environments"
+      "https://test.com/projects/ffzefzef3/environments"
     );
 
     environment.getMetrics().then(metrics => {

--- a/test/EnvironmentAccess.spec.js
+++ b/test/EnvironmentAccess.spec.js
@@ -18,14 +18,14 @@ describe("Environment Access", () => {
 
   it("Get environment access", async () => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/environments/1/access",
+      "https://test.com/projects/ffzefzef3/environments/1/access",
       [
         {
           id: "alice",
           _links: {
             self: {
               href:
-                "https://test.com/api/projects/ffzefzef3/environments/1/access/alice",
+                "https://test.com/projects/ffzefzef3/environments/1/access/alice",
               meta: {
                 get: {
                   responses: {
@@ -77,12 +77,12 @@ describe("Environment Access", () => {
       {
         _links: {
           "#manage-access": {
-            href: "/api/projects/ffzefzef3/environments/1/access"
+            href: "/projects/ffzefzef3/environments/1/access"
           }
         },
         id: 1
       },
-      "https://test.com/api/projects/ffzefzef3/environments"
+      "https://test.com/projects/ffzefzef3/environments"
     );
 
     const accesses = await environment.getUsers();

--- a/test/Me.spec.js
+++ b/test/Me.spec.js
@@ -19,7 +19,7 @@ describe("Me", () => {
   });
 
   it("Get me", done => {
-    fetchMock.get(`${api_url}/platform/me`, {
+    fetchMock.get(`${api_url}/me`, {
       id: 1,
       display_name: "test",
       email: "test@test.com",
@@ -27,7 +27,7 @@ describe("Me", () => {
         {
           id: "ffzefzef",
           name: "greatProject",
-          endpoint: "http://test.com/api/projects/ffzefzef"
+          endpoint: "http://test.com/projects/ffzefzef"
         }
       ]
     });
@@ -41,19 +41,19 @@ describe("Me", () => {
   });
 
   it("Get and update me", done => {
-    fetchMock.get(`${api_url}/platform/me`, {
+    fetchMock.get(`${api_url}/me`, {
       id: 1,
       display_name: "test",
       projects: [
         {
           id: "ffzefzef",
           name: "greatProject",
-          endpoint: "http://test.com/api/projects/ffzefzef"
+          endpoint: "http://test.com/projects/ffzefzef"
         }
       ]
     });
 
-    fetchMock.patch(`${api_url}/platform/profiles/1`, {
+    fetchMock.patch(`${api_url}/profiles/1`, {
       id: 1,
       email: "test@test.com",
       picture: "testNewPic"

--- a/test/Organization.spec.js
+++ b/test/Organization.spec.js
@@ -16,7 +16,7 @@ describe("Organization", () => {
   });
 
   it("Get members", done => {
-    fetchMock.mock("https://api.platform.sh/api/organizations/1/members", [
+    fetchMock.mock("https://api.platform.sh/organizations/1/members", [
       { user: "1" }
     ]);
 
@@ -34,14 +34,14 @@ describe("Organization", () => {
 
   it("Add member", done => {
     fetchMock.mock(
-      "https://api.platform.sh/api/organizations/1/members",
+      "https://api.platform.sh/organizations/1/members",
       {},
       "POST"
     );
 
     const organization = new Organization(
       { id: 1 },
-      "https://api.platform.sh/api/organizations/1"
+      "https://api.platform.sh/organizations/1"
     );
 
     organization.addMember({ user: "test" }).then(result => {

--- a/test/PaymentSource.spec.js
+++ b/test/PaymentSource.spec.js
@@ -19,7 +19,7 @@ describe("PaymentSource", () => {
   });
 
   it("Get PaymentSource", done => {
-    fetchMock.mock(`${api_url}/platform/payment_source`, {
+    fetchMock.mock(`${api_url}/payment_source`, {
       count: 1,
       payment_source: {
         id: "12345",
@@ -48,7 +48,7 @@ describe("PaymentSource", () => {
   });
 
   it("Get PaymentSource SEPA", done => {
-    fetchMock.mock(`${api_url}/platform/payment_source`, {
+    fetchMock.mock(`${api_url}/payment_source`, {
       count: 1,
       payment_source: {
         id: "67890",
@@ -74,7 +74,7 @@ describe("PaymentSource", () => {
 
   it("Get PaymentSource return 404", done => {
     fetchMock.mock(
-      `${api_url}/platform/payment_source`,
+      `${api_url}/payment_source`,
       {},
       {
         title: "No sources on file.",
@@ -90,7 +90,7 @@ describe("PaymentSource", () => {
   });
 
   it("Get PaymentSource filter by uuid", done => {
-    fetchMock.mock(`${api_url}/platform/payment_source?owner=uuid`, {
+    fetchMock.mock(`${api_url}/payment_source?owner=uuid`, {
       count: 1,
       payment_source: {
         id: "12345"
@@ -105,7 +105,7 @@ describe("PaymentSource", () => {
   });
 
   it("Get PaymentSource with empty answer", done => {
-    fetchMock.mock(`${api_url}/platform/payment_source`, {
+    fetchMock.mock(`${api_url}/payment_source`, {
       count: 0,
       payment_source: {}
     });
@@ -117,7 +117,7 @@ describe("PaymentSource", () => {
   });
 
   it("Get PaymentSource allowed", done => {
-    fetchMock.mock(`${api_url}/platform/payment_source/allowed`, {
+    fetchMock.mock(`${api_url}/payment_source/allowed`, {
       count: 2,
       payment_sources: [
         { id: "12345", label: "credit-card" },
@@ -136,7 +136,7 @@ describe("PaymentSource", () => {
 
   it("Create payment source", done => {
     const mock = fetchMock.mock(
-      `${api_url}/platform/payment_source`,
+      `${api_url}/payment_source`,
       {
         id: "12345",
         type: "credit-card"
@@ -158,7 +158,7 @@ describe("PaymentSource", () => {
 
   it("Delete payment source", done => {
     const mock = fetchMock.mock(
-      `${api_url}/platform/payment_source`,
+      `${api_url}/payment_source`,
       {},
       {
         method: "DELETE",
@@ -174,7 +174,7 @@ describe("PaymentSource", () => {
 
   it("Create setup intent", done => {
     const mock = fetchMock.mock(
-      `${api_url}/platform/payment_source/intent`,
+      `${api_url}/payment_source/intent`,
       {
         client_secret: "qwerty",
         public_key: "azerty"

--- a/test/Project.spec.js
+++ b/test/Project.spec.js
@@ -16,7 +16,7 @@ describe("Project", () => {
   });
 
   it("Get users associated with a project", done => {
-    fetchMock.mock("https://test.com/api/projects/ffzefzef3/access", [
+    fetchMock.mock("https://test.com/projects/ffzefzef3/access", [
       { id: 1, role: "r1" },
       { id: 2, role: "r2" }
     ]);
@@ -24,11 +24,11 @@ describe("Project", () => {
       {
         _links: {
           access: {
-            href: "/api/projects/ffzefzef3/access"
+            href: "/projects/ffzefzef3/access"
           }
         }
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.getUsers().then(projectAccess => {
@@ -44,13 +44,13 @@ describe("Project", () => {
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
     const gitUrl = project.getGitUrl();
 
@@ -59,7 +59,7 @@ describe("Project", () => {
 
   it("Add user in a project", done => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/access",
+      "https://test.com/projects/ffzefzef3/access",
       {
         _embedded: {
           activities: [
@@ -76,19 +76,19 @@ describe("Project", () => {
       {
         _links: {
           access: {
-            href: "/api/projects/ffzefzef3/access"
+            href: "/projects/ffzefzef3/access"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.addUser("test@test.com", "admin").then(result => {
       assert.equal(result.constructor.name, "Result");
       assert.equal(
-        result.getActivities("https://test.com/api/projects/ffzefzef3")[0]
+        result.getActivities("https://test.com/projects/ffzefzef3")[0]
           .constructor.name,
         "Activity"
       );
@@ -98,7 +98,7 @@ describe("Project", () => {
 
   it("Add user in a project with bad role", done => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/access",
+      "https://test.com/projects/ffzefzef3/access",
       {
         _embedded: {
           activities: [
@@ -115,13 +115,13 @@ describe("Project", () => {
       {
         _links: {
           access: {
-            href: "/api/projects/ffzefzef3/access"
+            href: "/projects/ffzefzef3/access"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.addUser("test@test.com", "role").catch(err => {
@@ -132,7 +132,7 @@ describe("Project", () => {
 
   it("Add user in a project with bad email and role", done => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/access",
+      "https://test.com/projects/ffzefzef3/access",
       {
         _embedded: {
           activities: [
@@ -149,13 +149,13 @@ describe("Project", () => {
       {
         _links: {
           access: {
-            href: "/api/projects/ffzefzef3/access"
+            href: "/projects/ffzefzef3/access"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.addUser("test@test", "role").catch(err => {
@@ -166,20 +166,20 @@ describe("Project", () => {
   });
 
   it("Get environment", done => {
-    fetchMock.mock("https://test.com/api/projects/ffzefzef3/environments/1", {
+    fetchMock.mock("https://test.com/projects/ffzefzef3/environments/1", {
       id: 1
     });
     const project = new Project(
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.getEnvironment(1).then(environment => {
@@ -189,21 +189,20 @@ describe("Project", () => {
   });
 
   it("Get environments", done => {
-    fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/environments?limit=2",
-      [{ id: 1 }]
-    );
+    fetchMock.mock("https://test.com/projects/ffzefzef3/environments?limit=2", [
+      { id: 1 }
+    ]);
     const project = new Project(
       {
         _links: {
           environments: {
-            href: "/api/projects/ffzefzef3/environments"
+            href: "/projects/ffzefzef3/environments"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.getEnvironments(2).then(environments => {
@@ -214,16 +213,16 @@ describe("Project", () => {
   });
 
   it("Get environments without _links", done => {
-    fetchMock.mock("https://test.com/api/projects/ffzefzef3/environments", [
+    fetchMock.mock("https://test.com/projects/ffzefzef3/environments", [
       { id: 1 }
     ]);
     const project = new Project(
       {
-        endpoint: "https://test.com/api/projects/ffzefzef3",
+        endpoint: "https://test.com/projects/ffzefzef3",
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.getEnvironments().then(environments => {
@@ -234,20 +233,20 @@ describe("Project", () => {
   });
 
   it("Get domains", done => {
-    fetchMock.mock("https://test.com/api/projects/ffzefzef3/domains?limit=2", [
+    fetchMock.mock("https://test.com/projects/ffzefzef3/domains?limit=2", [
       { id: 1 }
     ]);
     const project = new Project(
       {
         _links: {
           domains: {
-            href: "/api/projects/ffzefzef3/domains"
+            href: "/projects/ffzefzef3/domains"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.getDomains(2).then(domains => {
@@ -258,24 +257,21 @@ describe("Project", () => {
   });
 
   it("Get domain", done => {
-    fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/domains/domainName",
-      {
-        id: 1,
-        name: "domainName"
-      }
-    );
+    fetchMock.mock("https://test.com/projects/ffzefzef3/domains/domainName", {
+      id: 1,
+      name: "domainName"
+    });
     const project = new Project(
       {
         _links: {
           domains: {
-            href: "/api/projects/ffzefzef3/domains"
+            href: "/projects/ffzefzef3/domains"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.getDomain("domainName").then(domain => {
@@ -286,22 +282,18 @@ describe("Project", () => {
   });
 
   it("Add domain", done => {
-    fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/domains",
-      {},
-      "POST"
-    );
+    fetchMock.mock("https://test.com/projects/ffzefzef3/domains", {}, "POST");
     const project = new Project(
       {
         _links: {
           domains: {
-            href: "/api/projects/ffzefzef3/domains"
+            href: "/projects/ffzefzef3/domains"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.addDomain("domainName").then(result => {
@@ -311,21 +303,20 @@ describe("Project", () => {
   });
 
   it("Get integrations", done => {
-    fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/integrations?limit=2",
-      [{}]
-    );
+    fetchMock.mock("https://test.com/projects/ffzefzef3/integrations?limit=2", [
+      {}
+    ]);
     const project = new Project(
       {
         _links: {
           integrations: {
-            href: "/api/projects/ffzefzef3/integrations"
+            href: "/projects/ffzefzef3/integrations"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.getIntegrations(2).then(integrations => {
@@ -336,20 +327,20 @@ describe("Project", () => {
   });
 
   it("Get integration", done => {
-    fetchMock.mock("https://test.com/api/projects/ffzefzef3/integrations/1", {
+    fetchMock.mock("https://test.com/projects/ffzefzef3/integrations/1", {
       id: 1
     });
     const project = new Project(
       {
         _links: {
           integrations: {
-            href: "/api/projects/ffzefzef3/integrations"
+            href: "/projects/ffzefzef3/integrations"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.getIntegration(1).then(integration => {
@@ -361,7 +352,7 @@ describe("Project", () => {
 
   it("Add integration", done => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/integrations",
+      "https://test.com/projects/ffzefzef3/integrations",
       {},
       "POST"
     );
@@ -369,13 +360,13 @@ describe("Project", () => {
       {
         _links: {
           integrations: {
-            href: "/api/projects/ffzefzef3/integrations"
+            href: "/projects/ffzefzef3/integrations"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.addIntegration("bitbucket").then(result => {
@@ -386,7 +377,7 @@ describe("Project", () => {
 
   it("Add integration with bad type", done => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/integrations",
+      "https://test.com/projects/ffzefzef3/integrations",
       {},
       "POST"
     );
@@ -394,13 +385,13 @@ describe("Project", () => {
       {
         _links: {
           integrations: {
-            href: "/api/projects/ffzefzef3/integrations"
+            href: "/projects/ffzefzef3/integrations"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.addIntegration("test").catch(err => {
@@ -410,20 +401,20 @@ describe("Project", () => {
   });
 
   it("Get activity", done => {
-    fetchMock.mock("https://test.com/api/projects/ffzefzef3/activities/1", {
+    fetchMock.mock("https://test.com/projects/ffzefzef3/activities/1", {
       id: 1
     });
     const project = new Project(
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.getActivity(1).then(activity => {
@@ -438,7 +429,7 @@ describe("Project", () => {
       "?type=theType&starts_at=2017-03-21T09%3A06%3A30.550116%2B00%3A00";
 
     fetchMock.mock(
-      `https://test.com/api/projects/ffzefzef3/activities${queryString}`,
+      `https://test.com/projects/ffzefzef3/activities${queryString}`,
       [
         {
           id: 1
@@ -449,13 +440,13 @@ describe("Project", () => {
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project
@@ -472,14 +463,14 @@ describe("Project", () => {
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
         title: "project title",
         status: "suspended"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     assert.equal(project.isSuspended(), true);
@@ -488,7 +479,7 @@ describe("Project", () => {
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
@@ -497,7 +488,7 @@ describe("Project", () => {
           suspended: true
         }
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     assert.equal(project.isSuspended(), true);
@@ -508,14 +499,14 @@ describe("Project", () => {
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
         title: "project title",
         status: "ok"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     assert.equal(project.isSuspended(), false);
@@ -524,7 +515,7 @@ describe("Project", () => {
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
@@ -533,33 +524,30 @@ describe("Project", () => {
           suspended: false
         }
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     assert.equal(project.isSuspended(), false);
   });
 
   it("Get variables", done => {
-    fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/variables?limit=1",
-      [
-        {
-          id: 1,
-          name: "theVariableName"
-        }
-      ]
-    );
+    fetchMock.mock("https://test.com/projects/ffzefzef3/variables?limit=1", [
+      {
+        id: 1,
+        name: "theVariableName"
+      }
+    ]);
     const project = new Project(
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.getVariables(1).then(activities => {
@@ -571,7 +559,7 @@ describe("Project", () => {
 
   it("Get variable", done => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/variables/theVariableName",
+      "https://test.com/projects/ffzefzef3/variables/theVariableName",
       {
         id: 1,
         name: "theVariableName"
@@ -581,13 +569,13 @@ describe("Project", () => {
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.getVariable("theVariableName").then(activitie => {
@@ -599,11 +587,11 @@ describe("Project", () => {
 
   it("Set existing variable", done => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/variables/variableName",
+      "https://test.com/projects/ffzefzef3/variables/variableName",
       {
         _links: {
           "#edit": {
-            href: "/api/projects/ffzefzef3/variables/variableName"
+            href: "/projects/ffzefzef3/variables/variableName"
           }
         },
         id: 1,
@@ -611,12 +599,12 @@ describe("Project", () => {
       }
     );
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/variables",
+      "https://test.com/projects/ffzefzef3/variables",
       [
         {
           _links: {
             "#edit": {
-              href: "/api/projects/ffzefzef3/variables/variableName"
+              href: "/projects/ffzefzef3/variables/variableName"
             }
           },
           id: 1,
@@ -629,13 +617,13 @@ describe("Project", () => {
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.setVariable("variableName").then(result => {
@@ -645,20 +633,18 @@ describe("Project", () => {
   });
 
   it("Get certificates", done => {
-    fetchMock.mock("https://test.com/api/projects/ffzefzef3/certificates", [
-      {}
-    ]);
+    fetchMock.mock("https://test.com/projects/ffzefzef3/certificates", [{}]);
     const project = new Project(
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.getCertificates().then(certificates => {
@@ -670,7 +656,7 @@ describe("Project", () => {
 
   it("Add certificate", done => {
     fetchMock.mock(
-      "https://test.com/api/projects/ffzefzef3/certificates",
+      "https://test.com/projects/ffzefzef3/certificates",
       {},
       "POST"
     );
@@ -678,13 +664,13 @@ describe("Project", () => {
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.addCertificate("certif", "key", "chain").then(result => {
@@ -698,13 +684,13 @@ describe("Project", () => {
       {
         _links: {
           domains: {
-            href: "/api/projects/ffzefzef3/domains"
+            href: "/projects/ffzefzef3/domains"
           }
         },
         id: "ffzefzef3",
         title: "project title"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     const updatedProject = project.updateLocal({ title: "test" });
@@ -726,14 +712,14 @@ describe("Project", () => {
       {
         _links: {
           self: {
-            href: "/api/projects/ffzefzef3"
+            href: "/projects/ffzefzef3"
           }
         },
         id: "ffzefzef3",
         title: "project title",
         vendor_resources: "https://test.com"
       },
-      "https://test.com/api/projects/ffzefzef3"
+      "https://test.com/projects/ffzefzef3"
     );
 
     project.loadTheme().then(theme => {

--- a/test/Subscribe.spec.js
+++ b/test/Subscribe.spec.js
@@ -55,14 +55,14 @@ describe("Subscribe", () => {
   });
 
   it("Get subscription project", done => {
-    fetchMock.mock("https://test.com/api/projects/ffzefzef3", {
+    fetchMock.mock("https://test.com/projects/ffzefzef3", {
       id: 1,
       title: "theproject"
     });
     const subscription = new Subscription({
       _links: {
         project: {
-          href: "https://test.com/api/projects/ffzefzef3"
+          href: "https://test.com/projects/ffzefzef3"
         }
       },
       id: 1,

--- a/test/Team.spec.js
+++ b/test/Team.spec.js
@@ -16,9 +16,7 @@ describe("Team", () => {
   });
 
   it("Get members", done => {
-    fetchMock.mock("https://api.platform.sh/api/platform/teams/1/members", [
-      { user: "1" }
-    ]);
+    fetchMock.mock("https://api.platform.sh/teams/1/members", [{ user: "1" }]);
 
     const team = new Team({ id: 1 });
 
@@ -30,16 +28,9 @@ describe("Team", () => {
   });
 
   it("Add member", done => {
-    fetchMock.mock(
-      "https://api.platform.sh/api/platform/teams/1/members",
-      {},
-      "POST"
-    );
+    fetchMock.mock("https://api.platform.sh/teams/1/members", {}, "POST");
 
-    const team = new Team(
-      { id: 1 },
-      "https://api.platform.sh/api/platform/teams/1"
-    );
+    const team = new Team({ id: 1 }, "https://api.platform.sh/teams/1");
 
     team.addMember({ user: "test" }).then(result => {
       assert.equal(result.constructor.name, "Result");


### PR DESCRIPTION
The current api proxy is capable of re-routing the resource to the right  service without the need of the extra slugs.