### PR TITLE
fix token type usage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -715,7 +715,7 @@ export default class Client {
     return fetch(logUrl, {
       method: "GET",
       headers: {
-        Authorization: `${accessToken.token_type} ${accessToken.access_token}`
+        Authorization: `Bearer ${accessToken.access_token}`
       }
     });
   }


### PR DESCRIPTION
The `token_type` returned from the API is lower-case, but it expects it to be capitalized in the Authorization header.
See [RFC 6749, section 5.1](https://tools.ietf.org/html/rfc6749#section-5.1) and [RFC 6750, section 2.1](https://tools.ietf.org/html/rfc6750#section-2.1).

This won't be changed in the API so let's just use "Bearer" here, as no other token type can be used there anyway.