### PR TITLE
fix: avoids throwing errors if the operation is undefined

### DIFF
--- a/src/model/Ressource.js
+++ b/src/model/Ressource.js
@@ -246,12 +246,14 @@ export default class Ressource {
   /**
    * Check whether an operation is available on the resource.
    *
-   * @param string op
+   * @param {string} operationName
    *
-   * @return bool
+   * @return {boolean} true if the operation is available false otherwise
    */
-  operationAvailable(op) {
-    return this.data._links[`#${op}`].href;
+  operationAvailable(operationName) {
+    const links = this.data._links;
+    const operation = links && links[`#${operationName}`];
+    return operation?.href;
   }
 
   /**
@@ -353,7 +355,7 @@ export default class Ressource {
    */
   runOperation(op, method = "POST", body) {
     if (!this.operationAvailable(op)) {
-      throw new Error(`Oper tion not available: ${op}`);
+      throw new Error(`Operation not available: ${op}`);
     }
     return request(this.getLink(`#${op}`), method, body);
   }

--- a/test/Ressource.spec.js
+++ b/test/Ressource.spec.js
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import Ressource from "../src/model/Ressource";
+
+class MockResource extends Ressource {}
+
+describe("Ressource", () => {
+  describe("operationAvailable", () => {
+    it("Doesn't throw if _links is undefined", () => {
+      const data = {};
+      const resource = new MockResource("/test", {}, {}, data);
+
+      expect(() => resource.operationAvailable("test")).not.to.throw();
+    });
+
+    it("Doesn't throw if the operation is not present", () => {
+      const data = {
+        _links: {}
+      };
+      const resource = new MockResource("/test", {}, {}, data);
+
+      expect(() => resource.operationAvailable("test")).not.to.throw();
+    });
+  });
+
+  describe("runOperation", () => {
+    it("Throws if the operation is not available", () => {
+      const data = {
+        _links: {}
+      };
+      const resource = new MockResource("/test", {}, {}, data);
+
+      expect(() => resource.runOperation("test")).to.throw(
+        "Operation not available: test"
+      );
+    });
+  });
+});


### PR DESCRIPTION
If the operation is not present on the _links metadata the function should return false instead of throwing an error.