### PR TITLE
Add no cache option

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -30,7 +30,8 @@ export const request = (
   method,
   data,
   additionalHeaders = {},
-  retryNumber = 0
+  retryNumber = 0,
+  options = {}
 ) => {
   let body = data && { ...data };
   let apiUrl = url;
@@ -43,6 +44,7 @@ export const request = (
 
   const requestConfig = {
     method,
+    ...options,
     headers: { ...defaultHeaders, ...additionalHeaders }
   };
 
@@ -65,7 +67,8 @@ export const request = (
                   method,
                   data,
                   additionalHeaders,
-                  retryNumber + 1
+                  retryNumber + 1,
+                  options
                 )
               );
             });
@@ -120,7 +123,8 @@ export const authenticatedRequest = (
   method,
   data,
   additionalHeaders = {},
-  retryNumber = 0
+  retryNumber = 0,
+  options = {}
 ) => {
   return authenticationPromise.then(token => {
     if (!token) {
@@ -148,7 +152,8 @@ export const authenticatedRequest = (
           method,
           data,
           additionalHeaders,
-          retryNumber + 1
+          retryNumber + 1,
+          options
         );
       });
     }
@@ -165,7 +170,8 @@ export const authenticatedRequest = (
         ...additionalHeaders,
         ...authenticationHeaders
       },
-      retryNumber
+      retryNumber,
+      options
     );
   });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ export default class Client {
    */
   getAccountInfo(reset = false) {
     if (!this.getAccountInfoPromise || reset) {
-      this.getAccountInfoPromise = entities.Me.get();
+      this.getAccountInfoPromise = entities.Me.get(reset);
     }
 
     return this.getAccountInfoPromise;

--- a/src/model/Me.js
+++ b/src/model/Me.js
@@ -37,10 +37,12 @@ export default class Me extends User {
     this.trial = false;
   }
 
-  static get() {
+  static get(reset = false) {
     const { api_url } = getConfig();
 
-    return super.get({}, `${api_url}${url}`);
+    return super.get({}, `${api_url}${url}`, {
+      cache: reset ? "reload" : "default"
+    });
   }
 
   async update(data) {

--- a/src/model/Ressource.js
+++ b/src/model/Ressource.js
@@ -67,10 +67,10 @@ export default class Ressource {
     return _url.substring(0, _url.lastIndexOf("/"));
   }
 
-  static get(_url, params, paramDefaults, queryParams) {
+  static get(_url, params, paramDefaults, queryParams, options) {
     const parsedUrl = _urlParser(_url, params, paramDefaults);
 
-    return request(parsedUrl, "GET", queryParams).then(data => {
+    return request(parsedUrl, "GET", queryParams, {}, 0, options).then(data => {
       return typeof data === "undefined"
         ? undefined
         : new this.prototype.constructor(data, parsedUrl, params);

--- a/src/model/User.js
+++ b/src/model/User.js
@@ -19,7 +19,7 @@ export default class User extends Ressource {
     this.username = "";
   }
 
-  static get(params, customUrl) {
+  static get(params, customUrl, options) {
     const { id, ...queryParams } = params;
     const { api_url } = getConfig();
 
@@ -27,7 +27,8 @@ export default class User extends Ressource {
       customUrl || `${api_url}${_url}/:id`,
       { id },
       paramDefaults,
-      queryParams
+      queryParams,
+      options
     );
   }
 


### PR DESCRIPTION
In some cases we need to add the option `cache: 'reload'` to the request, this PR adds this options.