### PR TITLE
Hotfix: don't throw error when pf:routes is not defined

### DIFF
--- a/src/model/Environment.ts
+++ b/src/model/Environment.ts
@@ -451,8 +451,10 @@ export default class Environment extends Ressource {
    * @return string[]
    */
   getRouteUrls() {
-    const routes = getLink(this.getLinks(), "pf:routes", { absolute: false, hrefOnly: false});
+    const links = this.getLinks()
+    if (!links) return [];
 
+    const routes =  links["pf:routes"]
     if (!routes || !Array.isArray(routes)) {
       return [];
     }


### PR DESCRIPTION
When an environment is inactive, `pf:routes` is not defined, but we don;t want throw an error.