### PR TITLE
add backups to subscription/getEstimate & modifiableFields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformsh-client",
-  "version": "0.1.192",
+  "version": "0.1.191",
   "description": "Isomorphic Javascript library for accessing the Platform.sh API",
   "browser": "lib/client/platform-api.js",
   "main": "lib/server/platform-api.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformsh-client",
-  "version": "0.1.191",
+  "version": "0.1.192",
   "description": "Isomorphic Javascript library for accessing the Platform.sh API",
   "browser": "lib/client/platform-api.js",
   "main": "lib/server/platform-api.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -592,6 +592,7 @@ export default class Client {
    * @param int    storage      The allowed storage per environment (in MiB).
    * @param int    environments The number of environments.
    * @param int    users        The number of users.
+   * @param string backups      The available backup sellables
    *
    * @return array An array containing at least 'total' (a formatted price).
    */
@@ -602,6 +603,7 @@ export default class Client {
     environments: number,
     user_licenses: number,
     big_dev: string,
+    backups?: string,
     format?: string,
     country_code?: string
   }) {

--- a/src/model/Subscription.ts
+++ b/src/model/Subscription.ts
@@ -19,7 +19,13 @@ const creatableField = [
   "default_branch"
 ];
 
-const modifiableField = ["plan", "environments", "storage", "big_dev"];
+const modifiableField = [
+  "plan",
+  "environments",
+  "storage",
+  "big_dev",
+  "backups"
+];
 
 const url = "/v1/subscriptions/:id";
 const STATUS_ACTIVE = "active";
@@ -51,6 +57,7 @@ export default class Subscription extends Ressource {
   environments: number;
   storage: number;
   big_dev: number;
+  backups: string;
   user_licenses: number;
   project_id: string;
   project_title: string;
@@ -85,6 +92,7 @@ export default class Subscription extends Ressource {
     this.environments = 0;
     this.storage = 0;
     this.big_dev = 0;
+    this.backups = "";
     this.user_licenses = 0;
     this.project_id = "";
     this.project_title = "";
@@ -243,7 +251,8 @@ export default class Subscription extends Ressource {
       storage: this.storage,
       environments: this.environments,
       user_licenses: this.users_licenses,
-      big_dev: this.big_dev || undefined
+      big_dev: this.big_dev || undefined,
+      backups: this.backups || undefined
     };
 
     return authenticatedRequest(

--- a/test/Client.spec.js
+++ b/test/Client.spec.js
@@ -430,10 +430,11 @@ describe("Client", () => {
       plan: "plan",
       storage: "storage",
       environments: "environments",
-      user_licenses: "users"
+      user_licenses: "users",
+      backups: "backups"
     };
     fetchMock.mock(
-      `${api_url}/v1/subscriptions/estimate?plan=plan&storage=storage&environments=environments&user_licenses=users`,
+      `${api_url}/v1/subscriptions/estimate?plan=plan&storage=storage&environments=environments&user_licenses=users&backups=backups`,
       {
         key: "value"
       }
@@ -461,7 +462,7 @@ describe("Client", () => {
 
   it("Get organization subscription estimate", done => {
     fetchMock.mock(
-      `${api_url}/organizations/aliceorg/subscriptions/estimate?plan=plan&storage=storage&environments=environments&user_licenses=users`,
+      `${api_url}/organizations/aliceorg/subscriptions/estimate?plan=plan&storage=storage&environments=environments&user_licenses=users&backups=backups`,
       {
         key: "value"
       }
@@ -471,7 +472,8 @@ describe("Client", () => {
         plan: "plan",
         storage: "storage",
         environments: "environments",
-        user_licenses: "users"
+        user_licenses: "users",
+        backups: "backups"
       })
 
       .then(estimate => {


### PR DESCRIPTION
Add backups field to getEstimate & modifiableFields in Subscription, to support upgrading Backups plan in Edit Plan page: https://lab.plat.farm/accounts/console/-/issues/85/

