### PR TITLE
Making project_id available on subscription modal

### DIFF
--- a/src/model/Subscription.ts
+++ b/src/model/Subscription.ts
@@ -105,6 +105,7 @@ export default class Subscription extends Ressource {
     this.created_at = "";
     this.users_licenses = 0;
     this.license_uri = "";
+    this.project_id = "";
   }
 
   static get(params: SubscriptionGetParams, customUrl?: string) {


### PR DESCRIPTION
Add `project_id` to the constructor for the subscription modal so we can use it.