### PR TITLE
On dev mode don't watch types and node_modules folders

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,9 @@ var config = {
   output: {
     filename: outputFile
   },
+  watchOptions: {
+    ignored: [/node_modules/, /types/]
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
To test `npm run dev` don't re-run forever even without any file changes.