### PR TITLE
Fix project invitation permission settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1448,7 +1448,10 @@ export default class Client {
     email: string,
     projectId: string,
     role: string,
-    permissions: Array<string>,
+    permissions: {
+      type: "production" | "development" | "staging";
+      role: "viewer" | "contributor" | "admin";
+    }[],
     force = false
   ) {
     const invitation = new entities.Invitation({


### PR DESCRIPTION
The resend invitation feature is broken on console due on part to this
We were passing an array of strings, but the API demands an array of
objects https://api.internal.platform.sh/docs/#operation/create-project-invite

See slack thread also https://platformsh.slack.com/archives/GBYL0CPUG/p1656489038807179