### PR TITLE
Environment type types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import connector, { JWTToken, wipeToken } from "./authentication";
 import { getConfig, setConfig, ClientConfiguration } from "./config";
 import entities from "./model";
 import Activity from "./model/Activity";
-import { CreateAccessParams } from "./model/EnvironmentType";
+import { AccessRole, CreateAccessParams, DeleteAccessParams, UpdateAccessParams } from "./model/EnvironmentType";
 import Me from "./model/Me";
 import { OrganizationSubscriptionGetParams } from "./model/OrganizationSubscription";
 import ProjectAccess from "./model/ProjectAccess";
@@ -1519,32 +1519,25 @@ export default class Client {
    *
    * @param {string} projectId
    * @param {string} environmentTypeId
-   * @param {ProjectAccess} access
+   * @param {string} accessId
+   * @param {AccessRole} role
    *
    * @returns {Promise} Promise that return an access object.
    */
-  async updateEnvironmentTypeAccess(projectId: string, environmentTypeId: string, access: ProjectAccess) {
-    return entities.EnvironmentType.updateAccess(
-      projectId,
-      environmentTypeId,
-      access
-    );
+  async updateEnvironmentTypeAccess(params: UpdateAccessParams) {
+    return entities.EnvironmentType.updateAccess(params);
   }
   /**
    * Delete project environment types accesses
    *
    * @param {string} projectId
    * @param {string} environmentTypeId
-   * @param {ProjectAccess} access
+   * @param {string} accessId
    *
    * @returns {Promise} Promise that return a Result.
    */
-  async deleteEnvironmentTypeAccess(projectId: string, environmentTypeId: string, access: ProjectAccess) {
-    return entities.EnvironmentType.deleteAccess(
-      projectId,
-      environmentTypeId,
-      access
-    );
+  async deleteEnvironmentTypeAccess(params: DeleteAccessParams) {
+    return entities.EnvironmentType.deleteAccess(params);
   }
   /**
    * create project environment types accesses
@@ -1552,18 +1545,12 @@ export default class Client {
    * @param {string} projectId
    * @param {string} environmentTypeId
    * @param {string} email
-   * @param {string} role
+   * @param {AccessRole} role
    *
    * @returns {Promise} Promise that return an access object.
    */
   async createEnvironmentTypeAccess(params: CreateAccessParams) {
-    const { projectId, environmentTypeId, email, role } = params
-    return entities.EnvironmentType.createAccess({
-      projectId,
-      environmentTypeId,
-      email,
-      role
-    });
+    return entities.EnvironmentType.createAccess(params);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1514,41 +1514,15 @@ export default class Client {
 
     return environmentTypes;
   }
-  /**
-   * Update project environment types accesses
-   *
-   * @param {string} projectId
-   * @param {string} environmentTypeId
-   * @param {string} accessId
-   * @param {AccessRole} role
-   *
-   * @returns {Promise} Promise that return an access object.
-   */
+
   async updateEnvironmentTypeAccess(params: UpdateAccessParams) {
     return entities.EnvironmentType.updateAccess(params);
   }
-  /**
-   * Delete project environment types accesses
-   *
-   * @param {string} projectId
-   * @param {string} environmentTypeId
-   * @param {string} accessId
-   *
-   * @returns {Promise} Promise that return a Result.
-   */
+
   async deleteEnvironmentTypeAccess(params: DeleteAccessParams) {
     return entities.EnvironmentType.deleteAccess(params);
   }
-  /**
-   * create project environment types accesses
-   *
-   * @param {string} projectId
-   * @param {string} environmentTypeId
-   * @param {string} email
-   * @param {AccessRole} role
-   *
-   * @returns {Promise} Promise that return an access object.
-   */
+
   async createEnvironmentTypeAccess(params: CreateAccessParams) {
     return entities.EnvironmentType.createAccess(params);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1551,15 +1551,18 @@ export default class Client {
    *
    * @param {string} projectId
    * @param {string} environmentTypeId
+   * @param {string} email
+   * @param {string} role
    *
    * @returns {Promise} Promise that return an access object.
    */
   async createEnvironmentTypeAccess(params: CreateAccessParams) {
-    const { projectId, environmentTypeId, access } = params
+    const { projectId, environmentTypeId, email, role } = params
     return entities.EnvironmentType.createAccess({
       projectId,
       environmentTypeId,
-      access
+      email,
+      role
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import connector, { JWTToken, wipeToken } from "./authentication";
 import { getConfig, setConfig, ClientConfiguration } from "./config";
 import entities from "./model";
 import Activity from "./model/Activity";
+import { CreateAccessParams } from "./model/EnvironmentType";
 import Me from "./model/Me";
 import { OrganizationSubscriptionGetParams } from "./model/OrganizationSubscription";
 import ProjectAccess from "./model/ProjectAccess";
@@ -1553,12 +1554,13 @@ export default class Client {
    *
    * @returns {Promise} Promise that return an access object.
    */
-  async createEnvironmentTypeAccess(projectId: string, environmentTypeId: string, access: ProjectAccess) {
-    return entities.EnvironmentType.createAccess(
+  async createEnvironmentTypeAccess(params: CreateAccessParams) {
+    const { projectId, environmentTypeId, access } = params
+    return entities.EnvironmentType.createAccess({
       projectId,
       environmentTypeId,
       access
-    );
+    });
   }
 
   /**

--- a/src/model/EnvironmentType.ts
+++ b/src/model/EnvironmentType.ts
@@ -17,6 +17,16 @@ export interface EnvironmentTypeQueryParams {
   [key: string]: any;
 };
 
+export type AccessRole = "admin" | "contributor" | "viewer"
+
+export interface CreateAccessParams {
+  projectId: string,
+  environmentTypeId: string,
+  access: {
+    email: string,
+    role: AccessRole
+  }
+}
 export default class EnvironmentType extends Ressource {
   id: string;
   accesses: Array<any>;
@@ -54,7 +64,8 @@ export default class EnvironmentType extends Ressource {
     );
   }
 
-  static createAccess(projectId: string, environmentTypeId: string, access: any) {
+  static createAccess(params: CreateAccessParams) {
+    const { projectId, environmentTypeId, access } = params
     const { api_url } = getConfig();
     const url = `${api_url}/projects/${projectId}/environment-types/${environmentTypeId}/access`;
     return request(url, "POST", {

--- a/src/model/EnvironmentType.ts
+++ b/src/model/EnvironmentType.ts
@@ -75,7 +75,7 @@ export default class EnvironmentType extends Ressource {
     );
   }
 
-  static createAccess(params: CreateAccessParams) {
+  static async createAccess(params: CreateAccessParams) {
     const { projectId, environmentTypeId, email, role } = params
     const { api_url } = getConfig();
     const url = `${api_url}/projects/${projectId}/environment-types/${environmentTypeId}/access`;
@@ -85,7 +85,7 @@ export default class EnvironmentType extends Ressource {
     }).then(response => new ProjectAccess(response._embedded.entity, url));
   }
 
-  static updateAccess(params: UpdateAccessParams) {
+  static async updateAccess(params: UpdateAccessParams) {
     const { projectId, environmentTypeId, accessId, role } = params
     const { api_url } = getConfig();
     const url = `${api_url}/projects/${projectId}/environment-types/${environmentTypeId}/access/${
@@ -96,7 +96,7 @@ export default class EnvironmentType extends Ressource {
     }).then(response => new ProjectAccess(response._embedded.entity, url));
   }
 
-  static deleteAccess(params: DeleteAccessParams) {
+  static async deleteAccess(params: DeleteAccessParams): Promise<{status: string, code: number}> {
     const { projectId, environmentTypeId, accessId } = params
     const { api_url } = getConfig();
     const url = `${api_url}/projects/${projectId}/environment-types/${environmentTypeId}/access/${

--- a/src/model/EnvironmentType.ts
+++ b/src/model/EnvironmentType.ts
@@ -25,6 +25,19 @@ export interface CreateAccessParams {
   email: string,
   role: AccessRole
 }
+export interface UpdateAccessParams {
+  projectId: string,
+  environmentTypeId: string,
+  accessId: string,
+  role: AccessRole
+}
+
+export interface DeleteAccessParams {
+  projectId: string,
+  environmentTypeId: string,
+  accessId: string,
+}
+
 export default class EnvironmentType extends Ressource {
   id: string;
   accesses: Array<any>;
@@ -72,20 +85,22 @@ export default class EnvironmentType extends Ressource {
     }).then(response => new ProjectAccess(response._embedded.entity, url));
   }
 
-  static updateAccess(projectId: string, environmentTypeId: string, access: any) {
+  static updateAccess(params: UpdateAccessParams) {
+    const { projectId, environmentTypeId, accessId, role } = params
     const { api_url } = getConfig();
     const url = `${api_url}/projects/${projectId}/environment-types/${environmentTypeId}/access/${
-      access.id
+      accessId
     }`;
     return request(url, "PATCH", {
-      role: access.role
+      role
     }).then(response => new ProjectAccess(response._embedded.entity, url));
   }
 
-  static deleteAccess(projectId: string, environmentTypeId: string, access: any) {
+  static deleteAccess(params: DeleteAccessParams) {
+    const { projectId, environmentTypeId, accessId } = params
     const { api_url } = getConfig();
     const url = `${api_url}/projects/${projectId}/environment-types/${environmentTypeId}/access/${
-      access.id
+      accessId
     }`;
     return request(url, "DELETE");
   }

--- a/src/model/EnvironmentType.ts
+++ b/src/model/EnvironmentType.ts
@@ -22,10 +22,8 @@ export type AccessRole = "admin" | "contributor" | "viewer"
 export interface CreateAccessParams {
   projectId: string,
   environmentTypeId: string,
-  access: {
-    email: string,
-    role: AccessRole
-  }
+  email: string,
+  role: AccessRole
 }
 export default class EnvironmentType extends Ressource {
   id: string;
@@ -65,12 +63,12 @@ export default class EnvironmentType extends Ressource {
   }
 
   static createAccess(params: CreateAccessParams) {
-    const { projectId, environmentTypeId, access } = params
+    const { projectId, environmentTypeId, email, role } = params
     const { api_url } = getConfig();
     const url = `${api_url}/projects/${projectId}/environment-types/${environmentTypeId}/access`;
     return request(url, "POST", {
-      email: access.email,
-      role: access.role
+      email,
+      role
     }).then(response => new ProjectAccess(response._embedded.entity, url));
   }
 


### PR DESCRIPTION
We were using ProjectAccess when we didn't need most of it
And to make it work we were using any. Passing the whole ProjectAccess
where the API only requires an email and a role, was making this more complex than needed
to work on console, since we needed to pass a whole access everywhere.