### PR TITLE
Avoids converting arrays to objects

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -66,7 +66,8 @@ export const request = (
   retryNumber: number = 0,
   options: RequestOptions = {}
 ): Promise<any> => {
-  let body = data && { ...data };
+  const body = data instanceof Array ? data && [...data] : data && { ...data };
+
   let apiUrl = url;
 
   if (method === "GET") {


### PR DESCRIPTION
If we pass an array on the data property it gets converted to object, we want to avoid this in order to be able to post to the new project-access endpoint.