### PR TITLE
make limit optional in the getEnvironmentVariables method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -260,7 +260,7 @@ export default class Client {
    *
    * @return ProjectLevelVariable[]
    */
-  getEnvironmentVariables(projectId: string, environmentId: string, limit: number) {
+  getEnvironmentVariables(projectId: string, environmentId: string, limit?: number) {
     return entities.Variable.query({ projectId, environmentId, limit });
   }
 


### PR DESCRIPTION
sometimes we don't need to pass a limit and this causes a type error on console.