### PR TITLE
Whitelist properties so we can access them without .data

### DIFF
--- a/src/model/AccountsProfile.ts
+++ b/src/model/AccountsProfile.ts
@@ -56,6 +56,8 @@ export default class AccountsProfile extends Ressource {
   ui_contrast: string;
   default_catalog: string;
   marketing: string;
+  billing_contact: string;
+  vat_number: string;
 
   constructor(profile: APIObject) {
     const { api_url } = getConfig();
@@ -83,6 +85,8 @@ export default class AccountsProfile extends Ressource {
     this.ui_contrast = "";
     this.default_catalog = "";
     this.marketing = "";
+    this.billing_contact = "";
+    this.vat_number = "";
   }
 
   static get(params: AccountsProfileGetParams, customUrl?: string) {

--- a/src/model/Activity.ts
+++ b/src/model/Activity.ts
@@ -41,6 +41,7 @@ export default class Activity extends Ressource {
   type: string;
   payload: Record<string, any>;
   description: string;
+  integration: string;
   timings: Record<string, string>;
 
   constructor(activity: APIObject, url: string) {
@@ -61,6 +62,7 @@ export default class Activity extends Ressource {
     this.type = "";
     this.payload = [];
     this.description = "";
+    this.integration = "";
     this.timings = {};
   }
 

--- a/src/model/Activity.ts
+++ b/src/model/Activity.ts
@@ -40,6 +40,7 @@ export default class Activity extends Ressource {
   started_at: string;
   type: string;
   payload: Record<string, any>;
+  description: string;
   timings: Record<string, string>;
 
   constructor(activity: APIObject, url: string) {
@@ -59,6 +60,7 @@ export default class Activity extends Ressource {
     this.started_at = "";
     this.type = "";
     this.payload = [];
+    this.description = "";
     this.timings = {};
   }
 

--- a/src/model/Domain.ts
+++ b/src/model/Domain.ts
@@ -22,6 +22,7 @@ export default class Domain extends Ressource {
   is_default = false;
   created_at = "";
   ssl = [];
+  updated_at = "";
 
   constructor(domain: APIObject, url: string) {
     super(

--- a/src/model/Environment.ts
+++ b/src/model/Environment.ts
@@ -83,6 +83,8 @@ export default class Environment extends Ressource {
   http_access: HttpAccess = {};
   is_main: boolean = false;
   type: string = "";
+  edge_hostname = "";
+  has_deployment = false;
 
   constructor(environment: APIObject, url: string) {
     super(url, paramDefaults, environment, environment, [], modifiableField);

--- a/src/model/Integration.ts
+++ b/src/model/Integration.ts
@@ -68,6 +68,7 @@ export interface IntegrationQueryParams {
 export default class Integration extends Ressource {
   id = "";
   type = "";
+  category = "";
 
   constructor(integration: APIObject, url: string) {
     super(

--- a/src/model/Integration.ts
+++ b/src/model/Integration.ts
@@ -69,6 +69,8 @@ export default class Integration extends Ressource {
   id = "";
   type = "";
   category = "";
+  from_address = "";
+  recipients = [];
 
   constructor(integration: APIObject, url: string) {
     super(

--- a/src/model/Integration.ts
+++ b/src/model/Integration.ts
@@ -65,12 +65,101 @@ export interface IntegrationQueryParams {
   [key: string]: any;
 }
 
+interface BitbucketAppCredentials {
+  key: string;
+  secret: string;
+}
+interface BitbucketAddonCredentials {
+  addon_key: string;
+  client_key: string;
+  shared_secret: string;
+};
+
 export default class Integration extends Ressource {
   id = "";
   type = "";
-  category = "";
-  from_address = "";
-  recipients = [];
+
+  // These properties may or may not exist on this object, depending on which
+  // type of integration it is.
+  // We need to add them all so that they can be accessed directly rather than
+  // going through the `.data` property that exists on Proxy objects.
+  //
+  // See https://api.platform.sh/docs/#tag/Third-Party-Integrations/operation/get-projects-integrations
+  // for examples of integration data returned for each integration type.
+
+  // BitbucketIntegration
+  app_credentials: BitbucketAppCredentials | undefined = undefined;
+  addon_credentials: BitbucketAddonCredentials | undefined = undefined;
+  repository: string | undefined = undefined;
+  fetch_branches: boolean | undefined = undefined;
+  prune_branches: boolean | undefined = undefined;
+  build_pull_requests: boolean | undefined = undefined;
+  resync_pull_requests: boolean | undefined = undefined;
+
+  // BitBucketServerIntegration
+  url: string | undefined = undefined;
+  username: string | undefined = undefined;
+  project: string | undefined = undefined;
+  pull_requests_clone_parent_data: boolean | undefined = undefined;
+
+  // BlackfireIntegration
+  environments_credentials: { [prop: string]: any } | undefined = undefined;
+  supported_runtimes: string[] | undefined = undefined;
+
+  // FastlyIntegration
+  events: string[] | undefined = undefined;
+  environments: string[] | undefined = undefined;
+  excluded_environments: string[] | undefined = undefined;
+  states: string[] | undefined = undefined;
+  result: string | undefined = undefined;
+  service_id: string | undefined = undefined;
+
+  // GithubIntegration
+  base_url: string | undefined = undefined;
+  build_draft_pull_requests: boolean | undefined = undefined;
+  build_pull_requests_post_merge: boolean | undefined = undefined;
+
+  // GitLabIntegration
+  // No new properties
+
+  // EmailIntegration
+  from_address: string | undefined = undefined;
+  recipients: string[] | undefined = undefined;
+
+  // PagerDutyIntegration
+  routing_key: string | undefined = undefined;
+
+  // SlackIntegration
+  channel: string | undefined = undefined;
+
+  // HealthWebHookIntegration
+  // No new properties
+
+  // HipChatIntegration
+  room: string | undefined = undefined;
+
+  // NewRelicIntegration
+  tls_verify: boolean | undefined = undefined;
+
+  // ScriptIntegration
+  script: string | undefined = undefined;
+
+  // SplunkIntegration
+  index: string | undefined = undefined;
+  sourcetype: string | undefined = undefined;
+
+  // SumologicIntegration
+  category: string | undefined = undefined;
+
+  // SyslongIntegration
+  host: string | undefined = undefined;
+  port: number | undefined = undefined;
+  protocol: string | undefined = undefined;
+  facility: number | undefined = undefined;
+  message_format: string | undefined = undefined;
+
+  // WebHookIntegration
+  shared_key: string | undefined = undefined;
 
   constructor(integration: APIObject, url: string) {
     super(

--- a/src/model/Me.ts
+++ b/src/model/Me.ts
@@ -42,6 +42,7 @@ export default class Me extends User {
   mail: string;
   trial: boolean;
   uuid: string;
+  current_trial: object;
 
   constructor(account: APIObject) {
     const { api_url } = getConfig();
@@ -60,6 +61,7 @@ export default class Me extends User {
     this.mail = "";
     this.trial = false;
     this.uuid = "";
+    this.current_trial = {};
   }
 
   static get(reset = false) {

--- a/src/model/OrganizationProfile.ts
+++ b/src/model/OrganizationProfile.ts
@@ -15,7 +15,9 @@ const modifiableField = [
   "marketing",
   "company_name",
   "security_contact",
-  "website_url"
+  "website_url",
+  "vat_number",
+  "billing_contact"
 ];
 
 export interface OrganizationProfilGetParams {
@@ -32,6 +34,7 @@ export default class OrganizationProfile extends Ressource {
   company_name: string;
   current_trial: string;
   website_url: string;
+  account_tier: string;
 
   constructor(profile: APIObject, customUrl?: string) {
     const { api_url } = getConfig();
@@ -53,6 +56,7 @@ export default class OrganizationProfile extends Ressource {
     this.company_name = "";
     this.website_url = "";
     this.current_trial = "";
+    this.account_tier = "";
   }
 
   static get(params: OrganizationProfilGetParams) {

--- a/src/model/OrganizationSubscription.ts
+++ b/src/model/OrganizationSubscription.ts
@@ -31,6 +31,7 @@ export interface CreateSubscriptionPayloadType {
 // TODO: solve the get and query function inheritance ts error
 export default class OrganizationSubscription extends Subscription {
   organization_id: string;
+  support_tier: string;
 
   constructor(subscription: APIObject, customUrl?: string) {
     const { organizationId } = subscription;
@@ -47,6 +48,7 @@ export default class OrganizationSubscription extends Subscription {
     this._creatableField.push("organizationId");
 
     this.organization_id = organizationId;
+    this.support_tier = "";
   }
 
   static async get(

--- a/src/model/Project.ts
+++ b/src/model/Project.ts
@@ -66,6 +66,7 @@ export default class Project extends Ressource {
   default_domain = "";
   organization_id = "";
   default_branch = "";
+  timezone = "";
 
   constructor(project: APIObject, url: string) {
     super(url, paramDefaults, {}, project, [], modifiableField);

--- a/src/model/Ressource.ts
+++ b/src/model/Ressource.ts
@@ -7,7 +7,8 @@ import {
   getRefs,
   hasLink,
   getLinkHref,
-  Link
+  Link,
+  Links
 } from "../refs";
 import request from "../api";
 import Result from "./Result";
@@ -31,9 +32,11 @@ const handler = {
   get(target: any, key: string) {
     if (
       typeof key !== "symbol" &&
-      !key.startsWith("_") &&
       key !== "data" &&
-      target.hasOwnProperty(key)
+      ((
+        (!key.startsWith("_")) &&
+        target.hasOwnProperty(key)
+      ) || ["_embedded", "_links"].includes(key))
     ) {
       return target.data && target.data[key];
     }
@@ -79,6 +82,9 @@ export default abstract class Ressource {
   protected _queryUrl?: string;
 
   private data?: APIObject;
+
+  public _links?: Record<string, Link>;
+  public _embedded?: Record<string, Array<object>>;
 
   constructor(
     _url: string,

--- a/src/model/Subscription.ts
+++ b/src/model/Subscription.ts
@@ -83,8 +83,9 @@ export default class Subscription extends Ressource {
   license_uri: string;
   organization_id: string;
   project_options: {
-    plan_title: Record<string, string>;
+    plan_title: Record<string, string>,
   };
+  enterprise_tag: string;
 
   constructor(subscription: APIObject, customUrl?: string) {
     const { api_url } = getConfig();
@@ -126,6 +127,7 @@ export default class Subscription extends Ressource {
     this.project_options = {
       plan_title: {}
     };
+    this.enterprise_tag = "";
   }
 
   static get(params: SubscriptionGetParams, customUrl?: string) {


### PR DESCRIPTION
(Redoing this PR since the previous one accidentally got merged)

This is step zero in the process of removing Proxy objects from the JS client. This adds a number of public fields that are currently being accessed in Console via the .data property instead of accessing them directly. I have also modified the get() method on our Proxy handler in order to allow access to _links and _embedded directly instead of having to use .data or getLink()/getEmbed().