### PR TITLE
add deployment_state to the root level environment object

### DIFF
--- a/src/model/Environment.ts
+++ b/src/model/Environment.ts
@@ -44,6 +44,12 @@ export enum Status {
   deleting = "deleting"
 };
 
+interface DeploymentState {
+  crons: object;
+  last_deployment_at: string | null;
+  last_deployment_successful: boolean;
+}
+
 export default class Environment extends Ressource {
   id: string = ""
   status: Status = Status.inactive;
@@ -62,6 +68,7 @@ export default class Environment extends Ressource {
   enable_smtp: boolean = false;
   has_code: boolean = false;
   deployment_target: string = "";
+  deployment_state: DeploymentState | object = {};
   http_access = {};
   is_main: boolean = false;
   type: string = "";


### PR DESCRIPTION
- Adding the return value `deployment_state ` to avoid the need of accessing via `data`.
- Initially my Typing was more specific but I ended up defaulting with the [documentations](https://api.platform.sh/docs/#tag/Environment/operation/list-projects-environments) example.