### PR TITLE
Fix derived field initiliazation in subscription

### DIFF
--- a/src/model/OrganizationSubscription.ts
+++ b/src/model/OrganizationSubscription.ts
@@ -32,7 +32,6 @@ export type CreateSubscriptionPayloadType = {
 // @ts-expect-error solve the get and query function inheritance ts error
 export default class OrganizationSubscription extends Subscription {
   organization_id: string;
-  support_tier: string;
 
   constructor(subscription: APIObject, customUrl?: string) {
     const { organizationId } = subscription;
@@ -49,7 +48,6 @@ export default class OrganizationSubscription extends Subscription {
     this._creatableField.push("organizationId");
 
     this.organization_id = organizationId;
-    this.support_tier = "";
   }
 
   static async get(


### PR DESCRIPTION
Support tier is instantiated both in the base class and derived class of **Subscription** and **OrganisationSubscription**. Because the parent class handles the construction of the class, reassigning the field in the derived class **Subscription** without a valid assignment leads to this field being wrongly assigned by overriding the parent's value to the default assignment 