### PR TITLE
Organization can create

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformsh-client",
-  "version": "0.1.263",
+  "version": "0.1.264-beta.1",
   "description": "Isomorphic Javascript library for accessing the Platform.sh API",
   "browser": "lib/client/platform-api.js",
   "main": "lib/server/platform-api.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformsh-client",
-  "version": "0.1.264-beta.1",
+  "version": "0.1.263",
   "description": "Isomorphic Javascript library for accessing the Platform.sh API",
   "browser": "lib/client/platform-api.js",
   "main": "lib/server/platform-api.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -569,6 +569,16 @@ export default class Client {
   }
 
   /**
+   * Get organization subscription can create, which determines if a
+   * new subscription can be created under an organization.
+   *
+   * @param string organizationId
+   */
+  async getOrganizationSubscriptionCanCreate(organizationId: string) {
+    return entities.OrganizationSubscription.getCanCreate({ organizationId });
+  }
+
+  /**
    * Get organization members.
    *
    * @param string organizationId

--- a/src/model/OrganizationSubscription.ts
+++ b/src/model/OrganizationSubscription.ts
@@ -1,3 +1,4 @@
+import { authenticatedRequest } from "../authentication";
 import { getConfig } from "../config";
 import urlParser from "../urlParser";
 
@@ -79,6 +80,15 @@ export default class OrganizationSubscription extends Subscription {
       {
         queryStringArrayPrefix: "[]"
       }
+    );
+  }
+
+  static async getCanCreate(params: OrganizationSubscriptionQueryParams) {
+    const { api_url } = getConfig();
+
+    return authenticatedRequest(
+      `${api_url}/organizations/${params.organizationId}/subscriptions/can-create`,
+      "GET"
     );
   }
 


### PR DESCRIPTION
This are the changes to add support to the new /can-create endpoint, which allow us to know if a new subscription can be created under an organization