### PR TITLE
Add resources limit property to subscription model

### DIFF
--- a/src/model/Subscription.ts
+++ b/src/model/Subscription.ts
@@ -67,6 +67,13 @@ type SellableType = {
   };
 };
 
+type ResourceType = {
+  cpu?: number;
+  environments?: number;
+  memory?: number;
+  storage?: number;
+};
+
 export default class Subscription extends Ressource {
   id: string;
   status: SubscriptionStatusEnum;
@@ -98,6 +105,14 @@ export default class Subscription extends Ressource {
     plan_title: Record<string, string>;
     sellables?: SellableType;
     initialize?: Record<string, string>;
+  };
+
+  resources_limit?: {
+    limit: ResourceType;
+    used: {
+      projects: Record<string, ResourceType>;
+      totals: ResourceType;
+    };
   };
 
   environment_options: string[];
@@ -148,6 +163,13 @@ export default class Subscription extends Ressource {
         observability_suite: { products: [], available: false }
       },
       initialize: {}
+    };
+    this.resources_limit = {
+      limit: {},
+      used: {
+        projects: {},
+        totals: {}
+      }
     };
     this.enterprise_tag = "";
     this.support_tier = "";


### PR DESCRIPTION
This PR adds new property returned by the api on subscription model.
```
...
    "resources_limit": {
        "limit": {
            "cpu": 4.5,
            "environments": 2,
            "memory": 12,
            "projects": 1,
            "storage": 20
        },
        "used": {
            "projects": {
                "2802932": {
                    "environments": 1
                    "cpu": 1,
                    "memory": 1
                },
                "2803412": {
                    "environments": 1
                    "cpu": 1,
                    "memory": 1
                },
            },
            "totals": {
                "cpu": 4,
                "memory": 1.75,
                "projects": 2,
                "storage": 0
            }
        }
    },
...
```