### PR TITLE
Remove deprecated getOrganizationEstimate function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -651,19 +651,6 @@ export default class Client {
   }
 
   /**
-   * Estimate the cost for an organization.
-   */
-  async getOrganizationEstimate(organizationId: string) {
-    const { api_url } = getConfig();
-
-    return request(
-      `${api_url}/organizations/${organizationId}/estimate`,
-      "POST",
-      {}
-    );
-  }
-
-  /**
    * Estimate the cost of a subscription for an organization.
    *
    * @param string plan         The plan (see Subscription::$availablePlans).


### PR DESCRIPTION
Removes the deprecated `getOrganizationEstimate`.