### PR TITLE
Passes the amr values to the extra challenge params

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -49,10 +49,13 @@ const getChallengeExtraParams = (headers: Headers): Record<string, string> => {
   const wwwAuthentication = decodeHeaderString(
     headers.get("WWW-Authenticate") ?? ""
   );
-  return ["max_age", "acr_values"].reduce<Record<string, string>>((acc, cu) => {
-    if (wwwAuthentication[cu]) acc[cu] = wwwAuthentication[cu];
-    return acc;
-  }, {});
+  return ["amr", "max_age", "acr_values"].reduce<Record<string, string>>(
+    (acc, cu) => {
+      if (wwwAuthentication[cu]) acc[cu] = wwwAuthentication[cu];
+      return acc;
+    },
+    {}
+  );
 };
 
 export const request = async (


### PR DESCRIPTION
The amr values are required to be passed down after receiving a 401 related to SSO.