### PR TITLE
Connected accounts: adds new api field

### DIFF
--- a/src/model/ConnectedAccount.ts
+++ b/src/model/ConnectedAccount.ts
@@ -8,6 +8,7 @@ const _url = "/users/:userId/connections";
 
 export class ConnectedAccount extends Ressource {
   provider: string;
+  provider_type: string;
   subject: string;
   created_at: string;
   updated_at: string;
@@ -16,6 +17,8 @@ export class ConnectedAccount extends Ressource {
     super(url, {}, {}, connectedAccount, [], []);
 
     this.provider = connectedAccount.provider;
+    this.provider_type =
+      connectedAccount.provider_type || connectedAccount.provider;
     this.subject = connectedAccount.subject;
     this.created_at = connectedAccount.created_at;
     this.updated_at = connectedAccount.updated_at;


### PR DESCRIPTION
The API will provide a new `provider_type` field in the future. This should replace the `provider` field.
Will use provider as a fallback until the field is ready on the API.