### PR TITLE
Add company property to order model

### DIFF
--- a/src/model/Order.ts
+++ b/src/model/Order.ts
@@ -55,6 +55,7 @@ export class Order extends Ressource {
   status: string;
   owner: string;
   address: object;
+  company: string;
   vat_number: number;
   billing_period_start: string;
   billing_period_end: string;
@@ -82,6 +83,7 @@ export class Order extends Ressource {
     this.status = account.status;
     this.owner = account.owner;
     this.address = account.address ?? {};
+    this.company = account.company;
     this.vat_number = account.vat_number;
     this.billing_period_start = account.billing_period_start;
     this.billing_period_end = account.billing_period_end;


### PR DESCRIPTION
See https://linear.app/platformsh/issue/FRONT-889/expose-the-company-name-on-orders

Accounts has added `.company` to the orders API response as of Dec 4.

```
❯ platform api:curl organizations/01JAQV3NMXAT3WYT6SJ0E4VQ6R/orders/2900350 | jq .company
"test"
```