### PR TITLE
Add weight subproperty to components

### DIFF
--- a/src/model/Order.ts
+++ b/src/model/Order.ts
@@ -93,7 +93,7 @@ export class Order extends Ressource {
     this.last_refreshed = account.last_refreshed;
     this.total = account.total;
     this.total_formatted = account.total_formatted;
-    this.components = account.components ?? {};
+    this.components = Order.sortByWeight(account.components ?? {});
     this.currency = account.currency;
     this.invoice_url = account.invoice_url;
     this.line_items = account.line_items ?? [];
@@ -122,5 +122,18 @@ export class Order extends Ressource {
       params,
       data => (data as CommerceOrderResponse)?.commerce_order
     );
+  }
+
+  static sortByWeight(
+    components: Record<string, LineItemComponent>
+  ): Record<string, LineItemComponent> {
+    const sortedKeys = Object.keys(components).sort(
+      (a, b) => (components[a].weight ?? 0) - (components[b].weight ?? 0)
+    );
+    const sortedComponents: Record<string, LineItemComponent> = {};
+    for (const key of sortedKeys) {
+      sortedComponents[key] = components[key];
+    }
+    return sortedComponents;
   }
 }


### PR DESCRIPTION
Optional subproperty to determine components ordering.

See e.g.,

```
❯ pstaging api:curl orders/2822611 | jq .components
{
  "base_price": {
    "display_title": "Subtotal",
    "amount": 28.68,
    "currency": "CAD",
    "formatted": "$28.68 CAD",
    "weight": -100
  },
  "organization_inactivity_discount": {
    "display_title": "Organization inactivity discount",
    "amount": 0,
    "currency": "CAD",
    "formatted": "$0.00 CAD",
    "weight": -50
  },
  "trial": {
    "display_title": "Trial",
    "amount": 0,
    "currency": "CAD",
    "formatted": "$0.00 CAD",
    "weight": 0
  },
  "tax|gst": {
    "display_title": "5% GST",
    "amount": 0.56,
    "currency": "CAD",
    "formatted": "$0.56 CAD",
    "weight": 100
  },
  "allowance_discount": {
    "display_title": "First Project Incentive",
    "amount": -17.7,
    "currency": "CAD",
    "formatted": "-$17.70 CAD",
    "weight": -50
  }
}
```